### PR TITLE
Show login error

### DIFF
--- a/app/pages/AcountLogin/index.js
+++ b/app/pages/AcountLogin/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import c from 'classnames';
 import * as walletActions from '../../ducks/wallet';
 import './login.scss';
 import Submittable from '../../components/Submittable';
@@ -43,7 +44,9 @@ export default class AccountLogin extends Component {
         <Submittable onSubmit={() => this.handleLogin(passphrase)}>
           <div>
             <input
-              className="login_password_input"
+              className={c('login_password_input', {
+                'login_password_input--error': showError
+              })}
               type="password"
               placeholder="Your password"
               onChange={e =>

--- a/app/pages/AcountLogin/login.scss
+++ b/app/pages/AcountLogin/login.scss
@@ -22,6 +22,19 @@
   margin: 1rem 0 0 0;
   border: none;
   border-radius: 8px;
+
+  &--error {
+    animation: shake 0.5s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+    box-shadow: 0 0 0 1.25px rgba($orange-red, 0.6);
+
+    &:focus-within {
+      border-color: $orange-red;
+      box-shadow: 0 0 0 1.25px rgba($orange-red, 0.6);
+    }
+  }
 }
 
 .login_password_error {


### PR DESCRIPTION
![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/8077131/50782986-cf684180-12a9-11e9-955d-6b223c3521c3.gif)

- [x] Display error when login fails
- [x] Style input box red at error state
- [x] Cleaned up overall design of login screen

**note** There seems to be a bug that 'any' password unlocks your wallet after you logged in successfully and refresh the page. Will create a separate ticket for this.