### PR TITLE
Slide animations

### DIFF
--- a/app/components/Collapsible/collapsible.scss
+++ b/app/components/Collapsible/collapsible.scss
@@ -20,11 +20,17 @@
 
   &__content {
     opacity: 1;
-    transition: 0.3s linear;
+    // padding: 1rem;
+    position: relative;
+    max-height: 400px;
+    height: auto;
+    transition: 0.5s ease-out;
 
     &--hidden {
       opacity: 0;
-      transition: 0.3s linear;
+      max-height: 0;
+      overflow: hidden;
+      transition: 0.5s ease-out;
     }
   }
   

--- a/app/components/Collapsible/index.js
+++ b/app/components/Collapsible/index.js
@@ -53,13 +53,13 @@ export default class Collapsible extends Component {
   }
 
   renderContent() {
-    return this.state.isCollapsed
-      ? <div className="collapsible__content--hidden" />
-      : (
-        <div className="collapsible__content">
-          { this.props.children }
-        </div>
-      );
+    return (
+      <div className={cn('collapsible__content', {
+        'collapsible__content--hidden': this.state.isCollapsed
+      })} >  
+        { this.props.children }
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
![ezgif com-video-to-gif 10](https://user-images.githubusercontent.com/8077131/50842466-0b151100-1367-11e9-998a-bfea155740eb.gif)

- [x] Showing the collapsible slides the content down and pushed everything above with a slide effect
- [x] Also added an opacity effect to make it look smoother

**issue**: Current solution hardcodes the `max-height` of the div. This will be an issue if the bid history is 'higher' than `400px`. We could set the `max-height` of the bid history to `400px` and then add pagination. This might scale better in terms of design anyways.

**suggestion**: I'd simply use an opacity effect to avoid the height issue. If we want to keep the slide effect, [this post](https://css-tricks.com/using-css-transitions-auto-dimensions/) sums up our options well. TL;DR: Our best bet would be to use some JS, which is kind of a hack: https://codepen.io/marshallformula/pen/qPvWBL

Curious to hear your feedback on this. 