### PR TITLE
Display total value received by all outputs in TX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fixed total amount received by a transaction with multiple outputs to the wallet
+
 ## [0.2.8] - 2020-03-17
 ### Fixed
 - Fixed a crash when names transitioned from the bidding to revealing state

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -223,17 +223,24 @@ async function parseInputsOutputs(net, tx) {
     }
   }
 
+  let totalValue = 0;
+  let rec = false;
   for (const output of tx.outputs) {
     if (output.path) {
-      return {
-        type: isCoinbase ? 'COINBASE' : 'RECEIVE',
-        meta: {
-          from: isCoinbase ? '' : tx.inputs[0].address,
-        },
-        value: output.value,
-        fee: tx.fee,
-      };
+      rec = true;
+      totalValue += output.value;
     }
+  }
+
+  if (rec) {
+    return {
+      type: isCoinbase ? 'COINBASE' : 'RECEIVE',
+      meta: {
+        from: isCoinbase ? '' : tx.inputs[0].address,
+      },
+      value: totalValue,
+      fee: tx.fee,
+    };
   }
 
   return {


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/103

Displays the total amount received from all outputs in a wallet transaction, instead of just the first recognized output.