### PR TITLE
Warn users when bid is missing (from rescan) and allow repair of missing bid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed total amount received by a transaction with multiple outputs to the wallet
 
+### Added
+- Added warning for missing bid values and functionality to repair missing bids
+
 ## [0.2.8] - 2020-03-17
 ### Fixed
 - Fixed a crash when names transitioned from the bidding to revealing state

--- a/app/background/wallet/client.js
+++ b/app/background/wallet/client.js
@@ -28,4 +28,6 @@ export const clientStub = ipcRendererInjector => makeClient(ipcRendererInjector,
   'lock',
   'unlock',
   'isLocked',
+  'getNonce',
+  'importNonce',
 ]);

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -246,6 +246,15 @@ class WalletService {
     },
   );
 
+  getNonce = async (options) => {
+    this._ensureClient();
+    return this.client.getNonce(WALLET_ID, options.name, options);
+  };
+
+  importNonce = async (options) => {
+    return this._executeRPC('importnonce', [options.name, options.address, options.bid]);
+  }
+
   _onNodeStart = async (networkName, network, apiKey) => {
     this.networkName = networkName;
     const walletOptions = {
@@ -343,6 +352,8 @@ const methods = {
   lock: service.lock,
   unlock: service.unlock,
   isLocked: service.isLocked,
+  getNonce: service.getNonce,
+  importNonce: service.importNonce,
 };
 
 export async function start(server) {

--- a/app/components/SendModal/index.js
+++ b/app/components/SendModal/index.js
@@ -185,7 +185,7 @@ class SendModal extends Component {
               <input
                 type="number"
                 min={0}
-                placeholder="0.00000"
+                placeholder="0.000000"
                 onChange={this.updateAmount}
                 value={amount}
               />

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -227,7 +227,7 @@ class BidNow extends Component {
           <div className="domains__bid-now__own-highest-bid__title">Your Highest Bid</div>
           <div className="domains__bid-now__content">
             <AuctionPanelHeaderRow label="Total Bids:">
-              {displayBalance(totalBids, true)}
+              {totalBids < 0 ? '?' : displayBalance(totalBids, true)}
             </AuctionPanelHeaderRow>
             <AuctionPanelHeaderRow label="Total Masks:">
               {displayBalance(totalMasks, true)}
@@ -357,6 +357,10 @@ function getTotalBids(domain) {
 
   for (const {bid} of domain.bids) {
     if (bid.own) {
+      // This is our bid, but we don't know its value
+      if (!bid.value)
+        return -1;
+
       total += bid.value;
     }
   }

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -146,7 +146,7 @@ class Reveal extends Component {
     }
 
     if (needsRepair) {
-      text = 'Repair unknown bids';
+      text = 'Repair Unknown Bids';
       cname = 'domains__bid-now__action__warning';
     }
 

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -114,7 +114,7 @@ class Reveal extends Component {
         <div className="domains__bid-now__title">Your Bids</div>
         <div className="domains__bid-now__content">
           <AuctionPanelHeaderRow label="Total Bids:">
-            {displayBalance(totalBids, true)}
+            {totalBids < 0 ? '?' : displayBalance(totalBids, true)}
           </AuctionPanelHeaderRow>
           <AuctionPanelHeaderRow label="Total Masks:">
             {displayBalance(totalMasks, true)}
@@ -131,9 +131,11 @@ class Reveal extends Component {
       hasRevealableBid,
       hasRevealed,
       hasPendingReveal,
+      needsRepair,
     } = this.props;
 
     let text = 'Reveal Your Bids';
+    let cname = 'domains__bid-now__action__cta'
 
     if (hasRevealed) {
       text = 'Bid Successfully Revealed';
@@ -143,12 +145,17 @@ class Reveal extends Component {
       text = 'Reveal Pending...';
     }
 
+    if (needsRepair) {
+      text = 'Repair unknown bids';
+      cname = 'domains__bid-now__action__warning';
+    }
+
     return (
       <div className="domains__bid-now__action">
         <button
-          className="domains__bid-now__action__cta"
+          className={cname}
           onClick={this.sendReveal}
-          disabled={hasRevealed || hasPendingReveal || !hasRevealableBid}
+          disabled={hasRevealed || hasPendingReveal || !hasRevealableBid || needsRepair}
         >
           {text}
         </button>
@@ -176,6 +183,7 @@ export default connect(
     hasRevealableBid: _hasRevealableBid(domain),
     hasPendingReveal: _hasPendingReveal(domain),
     hasRevealed: _hasRevealed(domain),
+    needsRepair: getTotalBids(domain) < 0,
     totalBids: getTotalBids(domain),
     totalMasks: getTotalMasks(domain),
     network: state.node.network,
@@ -220,6 +228,10 @@ function getTotalBids(domain) {
 
   for (const {bid} of domain.bids) {
     if (bid.own) {
+      // This is our bid, but we don't know its value
+      if (!bid.value)
+        return -1;
+
       total += bid.value;
     }
   }

--- a/app/pages/Auction/BidHistory.js
+++ b/app/pages/Auction/BidHistory.js
@@ -11,6 +11,7 @@ export default class BidHistory extends Component {
     bids: PropTypes.array.isRequired,
     reveals: PropTypes.array.isRequired,
     getNameInfo: PropTypes.func.isRequired,
+    showError: PropTypes.func.isRequired,
   };
 
   render() {
@@ -62,8 +63,13 @@ export default class BidHistory extends Component {
               const bid = map[fromAddress];
               const {month, day, year} = bid.date;
               let bidValue = 'Hidden Until Reveal';
-              if (!bid.bid && bid.own)
-                bidValue = <RepairBid bid={bid} getNameInfo={this.props.getNameInfo}/>;
+              if (!bid.bid && bid.own) {
+                bidValue = <RepairBid
+                  bid={bid}
+                  getNameInfo={this.props.getNameInfo}
+                  showError={this.props.showError}
+                />;
+              }
               if (bid.bid)
                 bidValue = displayBalance(bid.bid, true);
               return (

--- a/app/pages/Auction/BidHistory.js
+++ b/app/pages/Auction/BidHistory.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import createAMPMTimeStamp from '../../utils/timeConverter';
 import { displayBalance } from '../../utils/balances';
 import ellipsify from '../../utils/ellipsify';
+import RepairBid from './RepairBid';
 import './bid-history.scss';
 
 export default class BidHistory extends Component {
   static propTypes = {
     bids: PropTypes.array.isRequired,
     reveals: PropTypes.array.isRequired,
+    getNameInfo: PropTypes.func.isRequired,
   };
 
   render() {
@@ -33,6 +35,9 @@ export default class BidHistory extends Component {
         bid: bid.bid.value,
         mask: bid.bid.lockup,
         own: bid.bid.own,
+        name: bid.bid.name,
+        from: bid.from,
+        blind: bid.bid.blind,
       }
     });
 
@@ -58,7 +63,7 @@ export default class BidHistory extends Component {
               const {month, day, year} = bid.date;
               let bidValue = 'Hidden Until Reveal';
               if (!bid.bid && bid.own)
-                bidValue = '⚠️ Unknown Bid';
+                bidValue = <RepairBid bid={bid} getNameInfo={this.props.getNameInfo}/>;
               if (bid.bid)
                 bidValue = displayBalance(bid.bid, true);
               return (

--- a/app/pages/Auction/BidHistory.js
+++ b/app/pages/Auction/BidHistory.js
@@ -56,11 +56,16 @@ export default class BidHistory extends Component {
             {order.map(fromAddress => {
               const bid = map[fromAddress];
               const {month, day, year} = bid.date;
+              let bidValue = 'Hidden Until Reveal';
+              if (!bid.bid && bid.own)
+                bidValue = '⚠️ Unknown Bid';
+              if (bid.bid)
+                bidValue = displayBalance(bid.bid, true);
               return (
                 <tr key={fromAddress}>
                   <td>{month}/{day}/{year}</td>
                   <td>{bid.own ? 'You' : ellipsify(fromAddress, 10)}</td>
-                  <td>{typeof bid.bid === 'number' ? displayBalance(bid.bid, true) : 'Hidden Until Reveal'}</td>
+                  <td>{bidValue}</td>
                   <td>{displayBalance(bid.mask, true)}</td>
                 </tr>
               )

--- a/app/pages/Auction/RepairBid.js
+++ b/app/pages/Auction/RepairBid.js
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import {consensus} from 'hsd/lib/protocol';
+import walletClient from '../../utils/walletClient';
+
+
+class RepairBid extends Component {
+  static propTypes = {
+    bid: PropTypes.object.isRequired,
+    getNameInfo: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isEditing: false,
+      value: "",
+      isCorrect: false,
+    };
+  }
+
+  renderRepairableBid() {
+    return (
+      <div
+        className="bid-history__repair-bid"
+        onClick={() => this.setState({isEditing: true})}
+      >
+        {"⚠️ Unknown Bid"}
+      </div>
+    );
+  }
+
+  renderInput() {
+    return (
+      <input
+        className={this.state.isCorrect ? 'bid-history__correct' : ''}
+        placeholder="0.000000"
+        value={this.state.value}
+        onChange={(e) => {
+            this.processValue(e.target.value);
+          }
+        }
+        disabled={this.state.isCorrect}
+      />      
+    );
+  }
+
+  processValue(val) {
+    const value = val.match(/[0-9]*\.?[0-9]{0,6}/g)[0];
+    if (value * consensus.COIN > consensus.MAX_MONEY)
+      return;
+    this.setState({value: value});
+    this.verifyBid(value);
+  }
+
+  verifyBid(value) {
+    const {bid} = this.props;
+    walletClient.getNonce({
+      name: bid.name,
+      address: bid.from,
+      bid: value * consensus.COIN
+    }).then((attempt) => {
+      if (attempt.blind === bid.blind)
+        this.setState({isCorrect: true});
+        walletClient.importNonce({
+          name: bid.name,
+          address: bid.from,
+          bid: parseFloat(value),
+        }).then(() => {
+          this.props.getNameInfo(bid.name);
+        });
+    });
+
+    
+  }
+
+  render() {
+    return this.state.isEditing
+    ? this.renderInput()
+    : this.renderRepairableBid();
+  }
+}
+
+export default RepairBid;

--- a/app/pages/Auction/bid-history.scss
+++ b/app/pages/Auction/bid-history.scss
@@ -31,4 +31,24 @@
       font-weight: 400;
     }
   }
+
+  &__correct {
+    background-color: $caribbean-green;
+  }
+
+  &__repair-bid {
+    display: inherit;
+    cursor: pointer;
+    border-bottom: 1px dashed lighten($manatee-gray, 25);
+
+    &:hover {
+      color: lighten($manatee-gray, 10);
+      border-bottom: 1px dashed lighten($manatee-gray, 30);
+    }
+
+    &:active {
+      color: darken($manatee-gray, 10);
+      border-bottom: 1px dashed lighten($manatee-gray, 20);
+    }
+  }
 }

--- a/app/pages/Auction/domains.scss
+++ b/app/pages/Auction/domains.scss
@@ -247,6 +247,33 @@
         font-weight: 600;
       }
 
+      &__warning {
+        @extend %btn-primary;
+        font-weight: 600;
+        color: $white;
+        background-color: $orange-red;
+        border: 1px solid $orange-red;
+
+        &:focus {
+          color: $white;
+          background-color: $orange-red;
+          border: 1px solid $orange-red;
+        }
+
+        &:hover {
+          color: $white;
+          background-color: $orange-red;
+          border: 1px solid $orange-red;
+        }
+
+        &:disabled {
+          background-color: $orange-red;
+          border: 1px solid $orange-red;
+          opacity: .5;
+          cursor: default;
+        }
+      }
+
       &__agreement {
         @extend %row-nowrap;
 

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -186,6 +186,7 @@ export default class Auction extends Component {
                 bids={this.props.domain.bids}
                 reveals={this.props.domain.reveals}
                 getNameInfo={this.props.getNameInfo}
+                showError={this.props.showError}
               /> :
               'Loading...'
             }

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -182,7 +182,11 @@ export default class Auction extends Component {
         <React.Fragment>
           <Collapsible className="domains__content__info-panel" title="Your Bids" pillContent={pillContent}>
             {this.props.domain ?
-              <BidHistory bids={this.props.domain.bids} reveals={this.props.domain.reveals} /> :
+              <BidHistory
+                bids={this.props.domain.bids}
+                reveals={this.props.domain.reveals}
+                getNameInfo={this.props.getNameInfo}
+              /> :
               'Loading...'
             }
           </Collapsible>

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -180,8 +180,7 @@ export default class Auction extends Component {
     if (isAvailable(domain) || isOpening(domain) || isBidding(domain) || isReveal(domain)) {
       return (
         <React.Fragment>
-          <Collapsible className="domains__content__info-panel" title="Your Bids" pillContent={pillContent}
-                       defaultCollapsed>
+          <Collapsible className="domains__content__info-panel" title="Your Bids" pillContent={pillContent}>
             {this.props.domain ?
               <BidHistory bids={this.props.domain.bids} reveals={this.props.domain.reveals} /> :
               'Loading...'


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/110

### Changes summary

- Added `importNonce` and `getNonce` to wallet IPC calls
- Fixed a typo in "send" modal (placeholder only had 5 decimals)
- Auction page:
  - List of bids is shown (not collapsed) by default for all states
  - If a bid is "owned" but had no "value" it is broken...
    - UI shows a red warning instead of reveal button
    - Total bids shows `?` instead of `NaN`
    - Bid value in table shows alert emoji with link to repair bid
      - User clicks to repair, enters values until they enter the correct value
      - Each change in the input computes a blind from the given value and compares against the known blind
      - Once the blinds match, the input is disabled, and briefly turns green while the nonce is imported to the wallet, and namestate is reloaded.


### A healthy wallet in reveal phase:

![Screen Shot 2020-03-25 at 1 49 18 PM](https://user-images.githubusercontent.com/2084648/77572596-a54a7180-6ea5-11ea-9640-24e163c2ec05.png)


### A wallet after rescan, "forgot" the bid value:

![Screen Shot 2020-03-25 at 1 50 55 PM](https://user-images.githubusercontent.com/2084648/77572612-af6c7000-6ea5-11ea-9e46-c570a83c1b4e.png)


### User enters the bid value they remember or have backed up:

![Mar-25-2020 14-28-09](https://user-images.githubusercontent.com/2084648/77572662-bf844f80-6ea5-11ea-9f99-55b524e0c293.gif)

