### PR TITLE
Rescan auction for existing bids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added warning for missing bid values and functionality to repair missing bids
 - Added wallet action in Settings page to delete unconfirmed transactions
+- Added "Rescan Auction" button to import name into wallet and discover existing bids
+- Automatically rescan auction if a user bids on a name that is not already in the wallet
+- Introduce "Wallet Sync" modal that blocks UI and displays wallet rescan progress
 
 ## [0.2.8] - 2020-03-17
 ### Fixed

--- a/app/background/wallet/client.js
+++ b/app/background/wallet/client.js
@@ -31,4 +31,5 @@ export const clientStub = ipcRendererInjector => makeClient(ipcRendererInjector,
   'getNonce',
   'importNonce',
   'zap',
+  'importName',
 ]);

--- a/app/background/wallet/client.js
+++ b/app/background/wallet/client.js
@@ -32,4 +32,5 @@ export const clientStub = ipcRendererInjector => makeClient(ipcRendererInjector,
   'importNonce',
   'zap',
   'importName',
+  'rpcGetWalletInfo',
 ]);

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -264,6 +264,10 @@ class WalletService {
     return this._executeRPC('importname', [name, start]);
   };
 
+  rpcGetWalletInfo = () => {
+    return this._executeRPC('getwalletinfo', []);
+  };
+
   _onNodeStart = async (networkName, network, apiKey) => {
     this.networkName = networkName;
     const walletOptions = {
@@ -365,6 +369,7 @@ const methods = {
   importNonce: service.importNonce,
   zap: service.zap,
   importName: service.importName,
+  rpcGetWalletInfo: service.rpcGetWalletInfo,
 };
 
 export async function start(server) {

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -260,6 +260,10 @@ class WalletService {
     return this.client.zap(WALLET_ID, 'default', 1);
   };
 
+  importName = (name, start) => {
+    return this._executeRPC('importname', [name, start]);
+  };
+
   _onNodeStart = async (networkName, network, apiKey) => {
     this.networkName = networkName;
     const walletOptions = {
@@ -360,6 +364,7 @@ const methods = {
   getNonce: service.getNonce,
   importNonce: service.importNonce,
   zap: service.zap,
+  importName: service.importName,
 };
 
 export async function start(server) {

--- a/app/components/Tooltipable/index.js
+++ b/app/components/Tooltipable/index.js
@@ -9,21 +9,23 @@ export default class Tooltipable extends Component {
     className: PropTypes.string,
     width: PropTypes.string,
     textAlign: PropTypes.string,
+    left: PropTypes.string,
   };
 
   static defaultProps = {
     className: '',
     width: '16rem',
     textAlign: 'left',
+    left: '0px',
   };
 
   render() {
-    const { children, tooltipContent, className, width, textAlign } = this.props;
+    const { children, tooltipContent, className, width, textAlign, left } = this.props;
 
     return (
       <div className={`tooltipable ${className}`}>
         {children}
-        <div className='tooltipable__tooltip' style={{ width, textAlign }}>   
+        <div className='tooltipable__tooltip' style={{ width, textAlign, left }}>   
           {tooltipContent}
         </div>
       </div>

--- a/app/components/WalletSync/index.js
+++ b/app/components/WalletSync/index.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import Modal from '../Modal';
+import './walletsync.scss';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import * as walletActions from '../../ducks/walletActions';
+
+@connect(
+  (state) => ({
+    walletSync: state.wallet.walletSync,
+    walletSyncProgress: state.wallet.walletSyncProgress,
+  })
+)
+export default class WalletSync extends Component {
+  static propTypes = {
+    walletSync: PropTypes.bool.isRequired,
+    walletSyncProgress: PropTypes.number.isRequired,
+  };
+
+  render() {
+    if (!this.props.walletSync) {
+      return null;
+    }
+
+    return (
+      <Modal className="wallet-sync__wrapper" onClose={() => ({})}>
+        <div className="wallet-sync__progress">
+          Syncing wallet... ({this.props.walletSyncProgress}%)
+        </div>
+      </Modal>
+    );
+  }
+}

--- a/app/components/WalletSync/walletsync.scss
+++ b/app/components/WalletSync/walletsync.scss
@@ -1,0 +1,20 @@
+@import "../../variables";
+
+.wallet-sync {
+  &__wrapper {
+    width: 15rem;
+    padding: 2rem 3rem;
+  }
+
+  &__progress {
+    @extend %box-input;
+    box-sizing: border-box;
+    width: 100%;
+    border: none;
+    border-radius: 8px;
+    
+    font-weight: 500;
+    font-size: 1.2rem;
+    text-align: center;
+  }
+}

--- a/app/ducks/names.js
+++ b/app/ducks/names.js
@@ -138,10 +138,13 @@ export const sendOpen = name => async (dispatch) => {
   await dispatch(fetchPendingTransactions());
 };
 
-export const sendBid = (name, amount, lockup) => async () => {
+export const sendBid = (name, amount, lockup, height) => async () => {
   if (!name) {
     return;
   }
+
+  if (height)
+    await walletClient.importName(name, height);
 
   await walletClient.sendBid(name, amount, lockup);
   await namesDb.storeName(name);

--- a/app/ducks/names.js
+++ b/app/ducks/names.js
@@ -41,6 +41,7 @@ export const getNameInfo = name => async (dispatch) => {
   let reveals = [];
   let winner = null;
   let isOwner = false;
+  let walletHasName = false;
   if (!info) {
     dispatch({
       type: SET_NAME,
@@ -52,6 +53,7 @@ export const getNameInfo = name => async (dispatch) => {
         reveals,
         winner,
         isOwner,
+        walletHasName,
       },
     });
     return;
@@ -59,6 +61,7 @@ export const getNameInfo = name => async (dispatch) => {
 
   try {
     const auctionInfo = await walletClient.getAuctionInfo(name);
+    walletHasName = true;
     bids = await inflateBids(nodeClient, walletClient, auctionInfo.bids, info.height);
     reveals = await inflateReveals(nodeClient, walletClient, auctionInfo.reveals, info.height);
   } catch (e) {
@@ -79,7 +82,7 @@ export const getNameInfo = name => async (dispatch) => {
 
   dispatch({
     type: SET_NAME,
-    payload: {name, start, info, bids, reveals, winner, isOwner},
+    payload: {name, start, info, bids, reveals, winner, isOwner, walletHasName},
   });
 };
 

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -143,7 +143,6 @@ export const waitForWalletSync = () => async (dispatch, getState) => {
     if (stall >= 5) {
       dispatch({type: STOP_SYNC_WALLET});
       throw new Error('Wallet sync progress has stalled.');
-      break;
     }
 
     if (progress === 100) {

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -113,6 +113,10 @@ export const startWalletSync = () => async (dispatch) => {
   await dispatch({type: START_SYNC_WALLET});
 };
 
+export const stopWalletSync = () => async (dispatch) => {
+  await dispatch({type: STOP_SYNC_WALLET});
+};
+
 export const waitForWalletSync = () => async (dispatch, getState) => {
   let lastProgress = 0;
   let stall = 0;

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -109,8 +109,11 @@ export const send = (to, amount, fee) => async (dispatch) => {
   return res;
 };
 
-export const waitForWalletSync = () => async (dispatch, getState) => {
+export const startWalletSync = () => async (dispatch) => {
   await dispatch({type: START_SYNC_WALLET});
+};
+
+export const waitForWalletSync = () => async (dispatch, getState) => {
   let lastProgress = 0;
   let stall = 0;
 

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -10,6 +10,9 @@ export const SET_TRANSACTIONS = 'app/wallet/setTransactions';
 export const INCREMENT_IDLE = 'app/wallet/incrementIdle';
 export const RESET_IDLE = 'app/wallet/resetIdle';
 export const SET_PENDING_TRANSACTIONS = 'app/wallet/setPendingTransactions';
+export const START_SYNC_WALLET = 'app/wallet/startSyncWallet';
+export const STOP_SYNC_WALLET = 'app/wallet/stopSyncWallet';
+export const SYNC_WALLET_PROGRESS = 'app/wallet/syncWalletProgress';
 
 export function getInitialState() {
   return {
@@ -24,6 +27,8 @@ export function getInitialState() {
     },
     transactions: [],
     idle: 0,
+    walletSync: false,
+    walletSyncProgress: 0,
   };
 }
 
@@ -72,6 +77,21 @@ export default function walletReducer(state = getInitialState(), {type, payload}
       return {
         ...state,
         idle: 0,
+      };
+    case START_SYNC_WALLET:
+      return {
+        ...state,
+        walletSync: true,
+      };
+    case STOP_SYNC_WALLET:
+      return {
+        ...state,
+        walletSync: false,
+      };
+    case SYNC_WALLET_PROGRESS:
+      return {
+        ...state,
+        walletSyncProgress: payload,
       };
     default:
       return state;

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -27,6 +27,7 @@ import AccountLogin from '../AcountLogin';
 import * as node from '../../ducks/node';
 import Notification from '../../components/Notification';
 import SplashScreen from "../../components/SplashScreen";
+import WalletSync from "../../components/WalletSync";
 import NetworkPicker from '../NetworkPicker';
 import IdleModal from '../../components/IdleModal';
 import { LedgerModal } from '../../components/LedgerModal';
@@ -66,6 +67,7 @@ class App extends Component {
 
     return (
       <div className="app">
+        <WalletSync />
         <IdleModal />
         {this.renderContent()}
       </div>

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -33,6 +33,7 @@ class BidNow extends Component {
     getNameInfo: PropTypes.func.isRequired,
     waitForWalletSync: PropTypes.func.isRequired,
     startWalletSync: PropTypes.func.isRequired,
+    stopWalletSync: PropTypes.func.isRequired,
   };
 
   state = {
@@ -85,6 +86,7 @@ class BidNow extends Component {
       analytics.track('sent bid');
     } catch (e) {
       console.error(e);
+      await this.props.stopWalletSync();
       logger.error(`Error received from BidNow - sendBid]\n\n${e.message}\n${e.stack}\n`);
       this.props.showError(`Failed to place bid: ${e.message}`);
     } finally {
@@ -100,6 +102,7 @@ class BidNow extends Component {
       await this.props.waitForWalletSync();
       await this.props.getNameInfo(domain.name);
     } catch (e) {
+      await this.props.stopWalletSync();
       this.props.showError(e.message);
     }
   }
@@ -396,6 +399,7 @@ export default connect(
     showSuccess: (message) => dispatch(showSuccess(message)),
     waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),
     startWalletSync: () => dispatch(walletActions.startWalletSync()),
+    stopWalletSync: () => dispatch(walletActions.stopWalletSync()),
     getNameInfo: tld => dispatch(nameActions.getNameInfo(tld)),
   }),
 )(BidNow);

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -32,6 +32,7 @@ class BidNow extends Component {
     confirmedBalance: PropTypes.number.isRequired,
     getNameInfo: PropTypes.func.isRequired,
     waitForWalletSync: PropTypes.func.isRequired,
+    startWalletSync: PropTypes.func.isRequired,
   };
 
   state = {
@@ -72,10 +73,9 @@ class BidNow extends Component {
       // for past bids before proceeding. The wallet will continue to track
       // newer bids automatically.
       if (!domain.walletHasName) {
-        walletClient.importName(domain.name, domain.info.height - 1).catch((e) => {
-          this.props.showError(e.message);
-        });
-        await this.props.waitForWalletSync()
+        await this.props.startWalletSync();
+        await walletClient.importName(domain.name, domain.info.height - 1);
+        await this.props.waitForWalletSync();
       }
 
       await sendBid(bidAmount, lockup);
@@ -98,10 +98,9 @@ class BidNow extends Component {
   rescanAuction = async () => {
     try {
       const {domain} = this.props;
-      walletClient.importName(domain.name, domain.info.height - 1).catch((e) => {
-        this.props.showError(e.message);
-      });
-      await this.props.waitForWalletSync()
+      await this.props.startWalletSync();
+      await walletClient.importName(domain.name, domain.info.height - 1);
+      await this.props.waitForWalletSync();
       await this.props.getNameInfo(domain.name);
     } catch (e) {
       this.props.showError(e.message);
@@ -399,6 +398,7 @@ export default connect(
     showError: (message) => dispatch(showError(message)),
     showSuccess: (message) => dispatch(showSuccess(message)),
     waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),
+    startWalletSync: () => dispatch(walletActions.startWalletSync()),
     getNameInfo: tld => dispatch(nameActions.getNameInfo(tld)),
   }),
 )(BidNow);

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -72,8 +72,10 @@ class BidNow extends Component {
       // for past bids before proceeding. The wallet will continue to track
       // newer bids automatically.
       if (!domain.walletHasName) {
-        this.props.waitForWalletSync();
-        await walletClient.importName(domain.name, domain.info.height - 1);
+        walletClient.importName(domain.name, domain.info.height - 1).catch((e) => {
+          this.props.showError(e.message);
+        });
+        await this.props.waitForWalletSync()
       }
 
       await sendBid(bidAmount, lockup);
@@ -87,17 +89,23 @@ class BidNow extends Component {
     } catch (e) {
       console.error(e);
       logger.error(`Error received from BidNow - sendBid]\n\n${e.message}\n${e.stack}\n`);
-      this.props.showError('Failed to place bid. Please try again.');
+      this.props.showError(`Failed to place bid: ${e.message}`);
     } finally {
       await this.props.getNameInfo(domain.name);  
     }
   };
 
   rescanAuction = async () => {
-    const {domain} = this.props;
-    this.props.waitForWalletSync();
-    await walletClient.importName(domain.name, domain.info.height - 1);
-    this.props.getNameInfo(domain.name);
+    try {
+      const {domain} = this.props;
+      walletClient.importName(domain.name, domain.info.height - 1).catch((e) => {
+        this.props.showError(e.message);
+      });
+      await this.props.waitForWalletSync()
+      await this.props.getNameInfo(domain.name);
+    } catch (e) {
+      this.props.showError(e.message);
+    }
   }
 
   render() {

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -399,6 +399,7 @@ export default connect(
     showError: (message) => dispatch(showError(message)),
     showSuccess: (message) => dispatch(showSuccess(message)),
     waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),
+    getNameInfo: tld => dispatch(nameActions.getNameInfo(tld)),
   }),
 )(BidNow);
 

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -69,16 +69,13 @@ class BidNow extends Component {
     const lockup = Number(disguiseAmount) + Number(bidAmount);
 
     try {
-      // If the name is not already stored in the wallet, rescan the auction
-      // for past bids before proceeding. The wallet will continue to track
-      // newer bids automatically.
-      if (!domain.walletHasName) {
-        await this.props.startWalletSync();
-        await walletClient.importName(domain.name, domain.info.height - 1);
-        await this.props.waitForWalletSync();
-      }
+      let height = null;
+      if (!domain.walletHasName)
+        height = domain.info.height - 1;
 
-      await sendBid(bidAmount, lockup);
+      await this.props.startWalletSync();
+      await sendBid(bidAmount, lockup, height);
+      await this.props.waitForWalletSync();
       this.setState({
         isReviewing: false,
         isPlacingBid: false,
@@ -394,7 +391,7 @@ export default connect(
     isPending: domain.pendingOperation === 'BID',
   }),
   (dispatch, {name}) => ({
-    sendBid: (amount, lockup) => dispatch(nameActions.sendBid(name, toBaseUnits(amount), toBaseUnits(lockup))),
+    sendBid: (amount, lockup, height) => dispatch(nameActions.sendBid(name, toBaseUnits(amount), toBaseUnits(lockup), height)),
     showError: (message) => dispatch(showError(message)),
     showSuccess: (message) => dispatch(showSuccess(message)),
     waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -74,9 +74,7 @@ class BidNow extends Component {
       if (!domain.walletHasName)
         height = domain.info.height - 1;
 
-      await this.props.startWalletSync();
       await sendBid(bidAmount, lockup, height);
-      await this.props.waitForWalletSync();
       this.setState({
         isReviewing: false,
         isPlacingBid: false,

--- a/app/pages/Auction/BidActionPanel/index.js
+++ b/app/pages/Auction/BidActionPanel/index.js
@@ -34,6 +34,7 @@ class BidActionPanel extends Component {
     getWatching: PropTypes.func.isRequired,
     watchDomain: PropTypes.func.isRequired,
     unwatchDomain: PropTypes.func.isRequired,
+    getNameInfo: PropTypes.func.isRequired,
   };
 
   state = {
@@ -114,6 +115,7 @@ class BidActionPanel extends Component {
         <BidNow
           domain={domain}
           name={name}
+          getNameInfo={this.props.getNameInfo}
         />
       );
     }

--- a/app/pages/Auction/BidActionPanel/index.js
+++ b/app/pages/Auction/BidActionPanel/index.js
@@ -34,7 +34,6 @@ class BidActionPanel extends Component {
     getWatching: PropTypes.func.isRequired,
     watchDomain: PropTypes.func.isRequired,
     unwatchDomain: PropTypes.func.isRequired,
-    getNameInfo: PropTypes.func.isRequired,
   };
 
   state = {
@@ -115,7 +114,6 @@ class BidActionPanel extends Component {
         <BidNow
           domain={domain}
           name={name}
-          getNameInfo={this.props.getNameInfo}
         />
       );
     }

--- a/app/pages/Auction/BidHistory.js
+++ b/app/pages/Auction/BidHistory.js
@@ -10,8 +10,6 @@ export default class BidHistory extends Component {
   static propTypes = {
     bids: PropTypes.array.isRequired,
     reveals: PropTypes.array.isRequired,
-    getNameInfo: PropTypes.func.isRequired,
-    showError: PropTypes.func.isRequired,
   };
 
   render() {
@@ -66,8 +64,6 @@ export default class BidHistory extends Component {
               if (!bid.bid && bid.own) {
                 bidValue = <RepairBid
                   bid={bid}
-                  getNameInfo={this.props.getNameInfo}
-                  showError={this.props.showError}
                 />;
               }
               if (bid.bid)

--- a/app/pages/Auction/RepairBid.js
+++ b/app/pages/Auction/RepairBid.js
@@ -3,9 +3,16 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {consensus} from 'hsd/lib/protocol';
 import walletClient from '../../utils/walletClient';
+import * as names from '../../ducks/names';
 
-
-class RepairBid extends Component {
+@connect(
+  () => ({}),
+  dispatch => ({
+    getNameInfo: tld => dispatch(names.getNameInfo(tld)),
+    showError: (message) => dispatch(showError(message)),
+  }),
+)
+export default class RepairBid extends Component {
   static propTypes = {
     bid: PropTypes.object.isRequired,
     getNameInfo: PropTypes.func.isRequired,
@@ -87,5 +94,3 @@ class RepairBid extends Component {
     : this.renderRepairableBid();
   }
 }
-
-export default RepairBid;

--- a/app/pages/Auction/domains.scss
+++ b/app/pages/Auction/domains.scss
@@ -434,6 +434,11 @@
       font-size: .75rem;
     }
 
+    &__rescan-tooltip {
+      vertical-align: bottom;
+      display: inline-block;
+    }
+
   }
 
 

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -111,23 +111,23 @@ export default class Auction extends Component {
     const {domain} = this.props;
 
     if (isReserved(domain)) {
-      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
+      return <BidActionPanel domain={domain} />;
     }
 
     if (this.isOwned()) {
-      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
+      return <BidActionPanel domain={domain} />;
     }
 
     if (isClosed(domain)) {
-      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
+      return <BidActionPanel domain={domain} />;
     }
 
     if (isOpening(domain) || isBidding(domain) || isReveal(domain)) {
-      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
+      return <BidActionPanel domain={domain} />;
     }
 
     if (isAvailable(domain)) {
-      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
+      return <BidActionPanel domain={domain} />;
     }
 
     return null;
@@ -185,8 +185,6 @@ export default class Auction extends Component {
               <BidHistory
                 bids={this.props.domain.bids}
                 reveals={this.props.domain.reveals}
-                getNameInfo={this.props.getNameInfo}
-                showError={this.props.showError}
               /> :
               'Loading...'
             }

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -111,23 +111,23 @@ export default class Auction extends Component {
     const {domain} = this.props;
 
     if (isReserved(domain)) {
-      return <BidActionPanel domain={domain} />;
+      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
     }
 
     if (this.isOwned()) {
-      return <BidActionPanel domain={domain} />;
+      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
     }
 
     if (isClosed(domain)) {
-      return <BidActionPanel domain={domain} />;
+      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
     }
 
     if (isOpening(domain) || isBidding(domain) || isReveal(domain)) {
-      return <BidActionPanel domain={domain} />;
+      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
     }
 
     if (isAvailable(domain)) {
-      return <BidActionPanel domain={domain} />;
+      return <BidActionPanel domain={domain} getNameInfo={this.props.getNameInfo} />;
     }
 
     return null;

--- a/app/pages/Onboarding/ImportSeedFlow/index.js
+++ b/app/pages/Onboarding/ImportSeedFlow/index.js
@@ -12,6 +12,7 @@ import walletClient from '../../../utils/walletClient';
 import * as logger from '../../../utils/logClient';
 import OptInAnalytics from '../OptInAnalytics';
 import { clientStub as aClientStub } from '../../../background/analytics/client';
+import { showError } from '../../../ducks/notifications';
 
 const analytics = aClientStub(() => require('electron').ipcRenderer);
 
@@ -29,6 +30,9 @@ class ImportSeedFlow extends Component {
     completeInitialization: PropTypes.func.isRequired,
     network: PropTypes.string.isRequired,
     waitForWalletSync: PropTypes.func.isRequired,
+    showError: PropTypes.func.isRequired,
+    fetchWallet: PropTypes.func.isRequired,
+    fetchTransactions: PropTypes.func.isRequired,
   };
 
   state = {
@@ -118,7 +122,10 @@ class ImportSeedFlow extends Component {
       await walletClient.importSeed(this.state.passphrase, mnemonic);
       await this.props.completeInitialization(this.state.passphrase);
       await this.props.waitForWalletSync();
+      await this.props.fetchWallet();
+      await this.props.fetchTransactions();
     } catch (e) {
+      this.props.showError(e.message);
       logger.error(`Error received from ImportSeedFlow - finishFlow]\n\n${e.message}\n${e.stack}\n`);
     } finally {
       this.setState({isLoading: false});
@@ -134,6 +141,9 @@ export default withRouter(
     dispatch => ({
       completeInitialization: (passphrase) => dispatch(walletActions.completeInitialization(passphrase)),
       waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),
+      showError: (message) => dispatch(showError(message)),
+      fetchWallet: () => dispatch(walletActions.fetchWallet()),
+      fetchTransactions: () => dispatch(walletActions.fetchTransactions()),
     }),
   )(ImportSeedFlow),
 );

--- a/app/pages/Onboarding/ImportSeedFlow/index.js
+++ b/app/pages/Onboarding/ImportSeedFlow/index.js
@@ -28,6 +28,7 @@ class ImportSeedFlow extends Component {
     }).isRequired,
     completeInitialization: PropTypes.func.isRequired,
     network: PropTypes.string.isRequired,
+    waitForWalletSync: PropTypes.func.isRequired,
   };
 
   state = {
@@ -116,6 +117,7 @@ class ImportSeedFlow extends Component {
     try {
       await walletClient.importSeed(this.state.passphrase, mnemonic);
       await this.props.completeInitialization(this.state.passphrase);
+      await this.props.waitForWalletSync();
     } catch (e) {
       logger.error(`Error received from ImportSeedFlow - finishFlow]\n\n${e.message}\n${e.stack}\n`);
     } finally {
@@ -131,6 +133,7 @@ export default withRouter(
     }),
     dispatch => ({
       completeInitialization: (passphrase) => dispatch(walletActions.completeInitialization(passphrase)),
+      waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),
     }),
   )(ImportSeedFlow),
 );

--- a/app/pages/Onboarding/ImportSeedFlow/index.js
+++ b/app/pages/Onboarding/ImportSeedFlow/index.js
@@ -29,6 +29,7 @@ class ImportSeedFlow extends Component {
     }).isRequired,
     completeInitialization: PropTypes.func.isRequired,
     network: PropTypes.string.isRequired,
+    startWalletSync: PropTypes.func.isRequired,
     waitForWalletSync: PropTypes.func.isRequired,
     showError: PropTypes.func.isRequired,
     fetchWallet: PropTypes.func.isRequired,
@@ -121,6 +122,7 @@ class ImportSeedFlow extends Component {
     try {
       await walletClient.importSeed(this.state.passphrase, mnemonic);
       await this.props.completeInitialization(this.state.passphrase);
+      await this.props.startWalletSync();
       await this.props.waitForWalletSync();
       await this.props.fetchWallet();
       await this.props.fetchTransactions();
@@ -141,6 +143,7 @@ export default withRouter(
     dispatch => ({
       completeInitialization: (passphrase) => dispatch(walletActions.completeInitialization(passphrase)),
       waitForWalletSync: () => dispatch(walletActions.waitForWalletSync()),
+      startWalletSync: () => dispatch(walletActions.startWalletSync()),
       showError: (message) => dispatch(showError(message)),
       fetchWallet: () => dispatch(walletActions.fetchWallet()),
       fetchTransactions: () => dispatch(walletActions.fetchTransactions()),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-wallet",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2028,13 +2028,12 @@
       }
     },
     "bcrypto": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.0.3.tgz",
-      "integrity": "sha512-wqATA9cenjBLDjih4Pey6H47G4RIpDzX4V3gvPTxsQkvVovYoERKyHR/BuUuxYllw5Xpi7novrogb/F/wN7xjA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.1.0.tgz",
+      "integrity": "sha512-WEs5g7WHdEdLLcsvhE7Z1AXv0G+hb+bJhSUYM7samFNrH051XhcFVWxAbAZDmIU1HWjpjhmQ+HqBar7UC/qrzQ==",
       "requires": {
         "bufio": "~1.0.6",
-        "loady": "~0.0.1",
-        "nan": "^2.14.0"
+        "loady": "~0.0.1"
       }
     },
     "bcurl": {
@@ -2196,12 +2195,12 @@
       "dev": true
     },
     "bns": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/bns/-/bns-0.10.2.tgz",
-      "integrity": "sha512-34AL03apeergw4rKtekOGYXTsbmSHQxxdOmFmFyWXYo+NxtCw/0FxgM6ssyK8XLtLH8LryyR6686FvjLxvjGQg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/bns/-/bns-0.11.0.tgz",
+      "integrity": "sha512-61FuOHkQ4EDFnYkNeLasnf4AAVr9N2DvGSCO95EK61lvUYmGQUCOVWppkC4dhNYm5Cr8n81xwjHJOZePnXlcIg==",
       "requires": {
-        "bcrypto": "~5.0.0",
-        "bfile": "~0.2.1",
+        "bcrypto": "~5.1.0",
+        "bfile": "~0.2.2",
         "bheep": "~0.1.5",
         "binet": "~0.3.5",
         "bs32": "~0.1.6",
@@ -2209,7 +2208,7 @@
         "btcp": "~0.1.5",
         "budp": "~0.1.6",
         "bufio": "~1.0.6",
-        "unbound": "~0.3.5"
+        "unbound": "~0.4.0"
       }
     },
     "body-parser": {
@@ -5873,14 +5872,13 @@
       }
     },
     "goosig": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.6.0.tgz",
-      "integrity": "sha512-jdSpZFwbj6A92qXpIhntHnGpGhCj/qlDHQ8YNHveCiaCd9VvF5FcFoDYHeoDYSc2WUYMx1H1OOq0ryWARlYNsQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.7.0.tgz",
+      "integrity": "sha512-FlTO9Ivch/uDFH8RSqEybb/vGt45BucaFZPpWuW7SZmfda8lw/s0zN296EJ8FmLyu8XP/T4KfGt4pzSIwgwNhg==",
       "requires": {
-        "bcrypto": "~5.0.0",
+        "bcrypto": "~5.1.0",
         "bsert": "~0.0.10",
-        "loady": "~0.0.1",
-        "nan": "^2.14.0"
+        "loady": "~0.0.1"
       }
     },
     "got": {
@@ -6098,12 +6096,12 @@
       }
     },
     "hsd": {
-      "version": "https://github.com/kyokan/hsd/tarball/bf9b1786b1ea0a1efa16e747a3f15124c17fc141",
-      "integrity": "sha512-jyhGDMWCrtELV6zXhcVNPjRsfff+1pCqBQL/5WER2GSQdo/Ycel48zh13ZgLS60vbgBbcIBEwqtR40PzxA+omQ==",
+      "version": "https://github.com/pinheadmz/hsd/tarball/f8b6de697952e68ba2ab0737ba8cec4db3f94a57",
+      "integrity": "sha512-nfN5AhLiGWI2ptJvOCMw6GbKvYqFVC2kQ6e+ffWaVyl511o3ZtkjVX03UnLm5dlZbYwNrxvL6TVXYBT4EE0bRA==",
       "requires": {
         "bcfg": "~0.1.6",
-        "bcrypto": "~5.0.3",
-        "bdb": "~1.1.7",
+        "bcrypto": "~5.1.0",
+        "bdb": "~1.2.1",
         "bdns": "~0.1.5",
         "bevent": "~0.1.5",
         "bfile": "~0.2.2",
@@ -6114,7 +6112,7 @@
         "blru": "~0.1.6",
         "blst": "~0.1.5",
         "bmutex": "~0.1.6",
-        "bns": "~0.10.2",
+        "bns": "~0.11.0",
         "bsert": "~0.0.10",
         "bsock": "~0.1.9",
         "bsocks": "~0.2.5",
@@ -6124,20 +6122,19 @@
         "bupnp": "~0.2.6",
         "bval": "~0.1.6",
         "bweb": "~0.1.10",
-        "goosig": "~0.6.0",
+        "goosig": "~0.7.0",
         "hs-client": "~0.0.8",
         "n64": "~0.2.10",
         "urkel": "~0.6.3"
       },
       "dependencies": {
-        "hs-client": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.8.tgz",
-          "integrity": "sha512-G5QZ1F1SFWRdxmbkqWEIfND8SeY4ZyG5xSebN3wthxBk+0uen2/7QTsfHpRvZWfIIHprt16wCLvel+sPE880eA==",
+        "bdb": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.2.1.tgz",
+          "integrity": "sha512-YASfideX6vIxsfqbP5Ky2zTQn56lSMSJSL6F/pku6Nh2K2cyO6TvD6qUJ9BJRXVzsKhwWSA1omzPhIgV9q+YNg==",
           "requires": {
-            "bcfg": "~0.1.6",
-            "bcurl": "~0.1.6",
-            "bsert": "~0.0.10"
+            "bsert": "~0.0.10",
+            "loady": "~0.0.1"
           }
         }
       }
@@ -7519,13 +7516,12 @@
       }
     },
     "mrmr": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.8.tgz",
-      "integrity": "sha512-lNav10EJsPZvlMqlBOYQ5atIO9jrlvbJ4/7asqunXY89dHooN5c+W6AV7jtvBRw4wFDR7TpEWfmBQgRGRVwBzA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.9.tgz",
+      "integrity": "sha512-t3nbygZEPN0vkoW+985GAVw/OOQODmAwPwCfaQUCQbTaZG40s7wmFaC8AKu4oL0g7hF4xcstwkvzW6bu4QxRSg==",
       "requires": {
         "bsert": "~0.0.10",
-        "loady": "~0.0.1",
-        "nan": "^2.13.1"
+        "loady": "~0.0.1"
       }
     },
     "ms": {
@@ -7557,7 +7553,8 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -10814,13 +10811,12 @@
       "dev": true
     },
     "unbound": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.3.5.tgz",
-      "integrity": "sha512-vnIkZGQswi7SVEnGI+25+oN9hLA7rc40zWi+xnzEwktNIZFtAC8PB/e5FMWgFoXUC4p2Jb/ZRNsZDcv3vivH+g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.4.1.tgz",
+      "integrity": "sha512-mFvPC0+H/vvyaKxqhfrLVTU2IvDPSIyJY/v8VosasCc6Fgm8NEkMwy5J1jaz2Ym4gvZFQWdLT4OiGwlEUKE7Yw==",
       "optional": true,
       "requires": {
-        "loady": "~0.0.1",
-        "nan": "^2.13.1"
+        "loady": "~0.0.1"
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "electron-updater": "4.1.2",
     "history": "4.7.2",
     "hs-client": "https://github.com/handshake-org/hs-client.git",
-    "hsd": "https://github.com/kyokan/hsd/tarball/bf9b1786b1ea0a1efa16e747a3f15124c17fc141",
+    "hsd": "https://github.com/pinheadmz/hsd/tarball/f8b6de697952e68ba2ab0737ba8cec4db3f94a57",
     "lodash.isequal": "4.5.0",
     "lodash.throttle": "4.1.1",
     "mixpanel": "0.10.2",


### PR DESCRIPTION
Closes #108 
Closes #113 

### Changes Summary

- Import branch of hsd with `rpc importname` (https://github.com/handshake-org/hsd/pull/408). We can wait until this is merged into master and rebase, but this branch is already based on latest hsd master.
- Expose wallet `rpc getwalletinfo` (as opposed to wallet HTTP `getinfo`), and `rpc importname` in background services.
- Add a few props and actions to redux store to start, stop, and monitor rescan progress.
- Introduce new modal that blocks the UI while the wallet is syncing. Progress is determined by comparing walletDB height with blockchain height. Modal applied to:
  - Importing seed and rescanning entire chain
  - Rescanning an in-progress auction to discover existing bids
- Auction rescanning is triggered by one of two actions:
  - Manually clicking "Rescan Auction" button on the auction page, _before_ a user has entered the auction (discover all existing bids _before_ a user places their first bid)
  - Automatically rescan auction when a user places a bid, if they have not already imported the name. 
- Minor:
  - Pass `left` prop to tooltip to keep hover-popups on the screen if they are too far to the right.
  - Add `walletHasName` to `domain` object, indicating the name is stored in the hsd wallet (which is separate from the Bob "watchlist" -- although they could be merged in the future)

### Potential issues

- When the user places a bid on a new auction, Bob will import the name and rescan the auction _before_ placing the bid. This is necessary because `importname` will throw if the name is already stored in the wallet, which it would be if the bid was sent first. This could be modified but I had issues finding existing bids after sending a bid, will investigate further.
- Rescans aren't dangerous (compared to a seed-importing-restore) but they do take a few seconds and might confuse the user.
- The WalletSync modal stays up until wallet sync is 100%. This should always happen eventually but there is no way to close the modal if something goes wrong. However, this would indicate a much bigger issue so maybe it's best to be "frozen" instead of the user thinking everything is OK.

### Rescan Auction button with hovering tooltip

![rescan-auciton-button](https://user-images.githubusercontent.com/2084648/78251604-97a57500-74bf-11ea-8f6e-2afa7c444c0c.png)

### Manually triggering auction rescan to load existing bids

![rescan-auction](https://user-images.githubusercontent.com/2084648/78251666-abe97200-74bf-11ea-9035-f9319aabad97.gif)

### Automatic auction rescan when placing first bid

This example bidding on a mainnet name auction just before close to give an upper-bound example on the amount of blocks to rescan.

![bid-auction-rescan](https://user-images.githubusercontent.com/2084648/78260653-2f10c500-74cc-11ea-91bb-cdf9f962c779.gif)
