### PR TITLE
Add "Delete unconfirmed transactions" wallet action to Settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added warning for missing bid values and functionality to repair missing bids
+- Added wallet action in Settings page to delete unconfirmed transactions
 
 ## [0.2.8] - 2020-03-17
 ### Fixed

--- a/app/background/logger/service.js
+++ b/app/background/logger/service.js
@@ -52,14 +52,14 @@ export async function log() {
   }
 }
 
-export async function download() {
+export async function download(network) {
   const udPath = app.getPath('userData');
-  const outputDir = path.join(udPath, 'hsd_output');
+  let outputDir = path.join(udPath, 'hsd_data');
 
-  let content = '';
+  if (network !== 'main')
+    outputDir = path.join(outputDir, network);
 
-  content += read(`${outputDir}/combined1.log`, 'utf8');
-  content += read(`${outputDir}/combined.log`, 'utf8');
+  const content = read(`${outputDir}/debug.log`);
 
   return content;
 }

--- a/app/background/wallet/client.js
+++ b/app/background/wallet/client.js
@@ -30,4 +30,5 @@ export const clientStub = ipcRendererInjector => makeClient(ipcRendererInjector,
   'isLocked',
   'getNonce',
   'importNonce',
+  'zap',
 ]);

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -253,7 +253,12 @@ class WalletService {
 
   importNonce = async (options) => {
     return this._executeRPC('importnonce', [options.name, options.address, options.bid]);
-  }
+  };
+
+  zap = async () => {
+    this._ensureClient();
+    return this.client.zap(WALLET_ID, 'default', 1);
+  };
 
   _onNodeStart = async (networkName, network, apiKey) => {
     this.networkName = networkName;
@@ -354,6 +359,7 @@ const methods = {
   isLocked: service.isLocked,
   getNonce: service.getNonce,
   importNonce: service.importNonce,
+  zap: service.zap,
 };
 
 export async function start(server) {

--- a/app/components/Checkbox/index.js
+++ b/app/components/Checkbox/index.js
@@ -8,14 +8,16 @@ export default class Checkbox extends Component {
     checked: PropTypes.bool,
     onChange: PropTypes.func,
     className: PropTypes.string,
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {
     className: '',
+    disabled: false,
   };
 
   render() {
-    const { className, checked, onChange } = this.props;
+    const { className, checked, onChange, disabled } = this.props;
 
     return (
       <div className={c('checkbox', className, { 'checkbox--checked': checked })}>
@@ -23,6 +25,7 @@ export default class Checkbox extends Component {
           type="checkbox"
           checked={checked}
           onChange={onChange}
+          disabled={disabled}
         />
       </div>
     );

--- a/app/components/Modal/MiniModal.js
+++ b/app/components/Modal/MiniModal.js
@@ -10,7 +10,8 @@ export class MiniModal extends Component {
     closeRoute: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
     title: PropTypes.string.isRequired,
-    centered: PropTypes.bool
+    centered: PropTypes.bool,
+    wide: PropTypes.bool,
   };
 
   onClose = () => {
@@ -19,7 +20,8 @@ export class MiniModal extends Component {
 
   render() {
     const names = classnames('mini-modal', {
-      'mini-modal--centered': this.props.centered
+      'mini-modal--centered': this.props.centered,
+      'mini-modal--wide': this.props.wide,
     });
 
     return (

--- a/app/components/Modal/mini-modal.scss
+++ b/app/components/Modal/mini-modal.scss
@@ -41,3 +41,7 @@
     text-align: center;
   }
 }
+
+.mini-modal--wide {
+  width: 80%;
+}

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -330,7 +330,15 @@ async function nameByHash(net, covenant) {
   if (nameCache.cache[hash]) {
     return nameCache.cache[hash];
   }
-  const name = await nodeClient.getNameByHash(hash);
+  let name = await nodeClient.getNameByHash(hash);
+
+  if (!name && covenant.action === 'OPEN') {
+    // Before an OPEN is confirmed, the name->hash mapping will not be present
+    // in the full node. Luckily, the name is included as an ASCII string in
+    // the covenant itself.
+    name = Buffer.from(covenant.items[2], 'hex').toString('ascii');
+  }
+
   if (name) {
     nameCache.cache[hash] = name;
   }

--- a/app/pages/Settings/ZapTXsModal.js
+++ b/app/pages/Settings/ZapTXsModal.js
@@ -7,18 +7,23 @@ import Checkbox from '../../components/Checkbox';
 import MiniModal from '../../components/Modal/MiniModal';
 import { fetchTransactions } from '../../ducks/walletActions';
 import walletClient from '../../utils/walletClient';
+import {showError, showSuccess } from '../../ducks/notifications';
 
 @connect(
   (state) => ({
     transactions: state.wallet.transactions,
   }),
   (dispatch) => ({
-    fetchTransactions: () => dispatch(fetchTransactions())
+    fetchTransactions: () => dispatch(fetchTransactions()),
+    showError: (message) => dispatch(showError(message)),
+    showSuccess: (message) => dispatch(showSuccess(message)),
   })
 )
 class ZapTXsModal extends Component {
   static propTypes = {
-    transactions: PropTypes.array.isRequired
+    transactions: PropTypes.array.isRequired,
+    showError: PropTypes.func.isRequired,
+    showSuccess: PropTypes.func.isRequired,
   };
 
   async componentDidMount() {
@@ -27,6 +32,16 @@ class ZapTXsModal extends Component {
 
   state = {
     accepted: false,
+  };
+
+  zapTXs = async () => {
+    this.props.history.push('/settings');
+    try {
+      await walletClient.zap();
+      this.props.showSuccess('All pending transactions have been deleted!');
+    } catch (e) {
+      this.props.showError(e.message);
+    }
   };
 
   render() {
@@ -97,7 +112,7 @@ class ZapTXsModal extends Component {
         <div className="">
           <button
             className="zap-txs-modal__action"
-            onClick={()=>{walletClient.zap(); this.props.history.push("/settings")}}
+            onClick={this.zapTXs}
             disabled={!this.state.accepted}
           >
             Delete Unconfirmed Transactions

--- a/app/pages/Settings/ZapTXsModal.js
+++ b/app/pages/Settings/ZapTXsModal.js
@@ -1,0 +1,111 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import './zap-txs-modal.scss';
+import Transaction from '../../components/Transactions/Transaction';
+import Checkbox from '../../components/Checkbox';
+import MiniModal from '../../components/Modal/MiniModal';
+import { fetchTransactions } from '../../ducks/walletActions';
+import walletClient from '../../utils/walletClient';
+
+@connect(
+  (state) => ({
+    transactions: state.wallet.transactions,
+  }),
+  (dispatch) => ({
+    fetchTransactions: () => dispatch(fetchTransactions())
+  })
+)
+class ZapTXsModal extends Component {
+  static propTypes = {
+    transactions: PropTypes.array.isRequired
+  };
+
+  async componentDidMount() {
+    await this.props.fetchTransactions()
+  }
+
+  state = {
+    accepted: false,
+  };
+
+  render() {
+    const txList = [];
+    let disabled = true;
+
+    if (this.props.transactions) {
+      const txs = [];
+
+      for (const tx of this.props.transactions) {
+        if (tx.pending)
+          txs.push(tx);
+      }
+
+      if (txs.length === 0) {
+        txList.push(
+          <div key="empty" className="transactions__empty-list">
+            You do not have any pending transactions.
+          </div>
+        );
+      }
+
+      for (const tx of txs) {
+        txList.push(
+          <div className="transaction__container" key={tx.id}>
+            <Transaction transaction={tx} />
+          </div>
+        );
+        disabled = false;
+      }
+    } else {
+      txList.push(
+        <div key="empty" className="transactions__empty-list">
+          Loading pending transactions...
+        </div>
+      );
+    }
+
+    return (
+      <MiniModal
+        closeRoute="/settings"
+        title="Delete unconfirmed transactions"
+        wide
+        centered
+      >
+        <div className="zap-txs-modal__tx-list">
+          {txList}
+        </div>
+        <div className="zap-txs-modal__checkbox">
+          <Checkbox
+            className="zap-txs-modal__checkbox-box"
+            onChange={() => {
+              this.setState({
+                accepted: !this.state.accepted
+              })
+            }}
+            checked={this.state.accepted}
+            disabled={disabled}
+          />
+          <div className="zap-txs-modal__checkbox-label">
+            I understand this will remove unconfirmed transactions from my wallet
+            but may not completely remove them from the network. They may still be
+            relayed between nodes and confirmed in blocks. By deleting pending
+            transactions this wallet may re-spend "stuck" coins, but those
+            new transactions are not garunteed to replace the originals.
+          </div>
+        </div>
+        <div className="">
+          <button
+            className="zap-txs-modal__action"
+            onClick={()=>{walletClient.zap(); this.props.history.push("/settings")}}
+            disabled={!this.state.accepted}
+          >
+            Delete Unconfirmed Transactions
+          </button>
+        </div>
+      </MiniModal>
+    );
+  }
+}
+
+export default ZapTXsModal;

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import './index.scss';
 import AccountIndexModal from './AccountIndexModal';
 import RevealSeedModal from './RevealSeedModal';
+import ZapTXsModal from './ZapTXsModal';
 import InterstitialWarningModal from './InterstitialWarningModal';
 import * as logger from '../../utils/logClient';
 import * as walletActions from '../../ducks/walletActions';
@@ -50,37 +51,49 @@ export default class Settings extends Component {
 
   render() {
     return (
-      <ContentArea title="Settings" noPadding>
-        <div className="settings__label">Network</div>
-        <div className="settings__dropdown">
-          <NetworkPicker />
-        </div>
+      <ContentArea noPadding>
+        <div className="settings__supersection">Wallet Actions</div>
+        <hr className="settings__separator"/>
         <ul className="settings__links">
           <li>
             <a href="#" onClick={this.props.lockWallet}>
-              Log out
+              Lock wallet and logout
             </a>
           </li>
+        </ul>
+        <ul className="settings__links">
+          <li>
+            <Link to="/settings/zap-txs">Delete unconfirmed transactions</Link>
+          </li>
+        </ul>
+        <ul className="settings__links">
+          <li>
+            <Link to="/settings/reveal-seed">Reveal recovery seed phrase</Link>
+          </li>
+        </ul>
+        <ul className="settings__links">
+          <li>
+            <Link to="/settings/new-wallet">Remove wallet and create new wallet</Link>
+          </li>
+        </ul>
+        <p />
+        <div className="settings__supersection">Advanced</div>
+        <hr className="settings__separator"/>
+        <div className="settings__section-head">HSD API Key</div>
+        <input type="text" className="settings__copy-api-key" value={this.props.apiKey} readOnly />
+        <p />
+        <div className="settings__section-head">Network</div>
+        <div className="settings__dropdown">
+          <NetworkPicker />
+        </div>
+        <div className="settings__section-head">Debug</div>
+        <ul className="settings__links">
           <li>
             <div className="settings__link" onClick={this.onDownload}>
-              Download logs
+              Download log
             </div>
           </li>
         </ul>
-        <div className="settings__section-head">Your recovery seed phrase</div>
-        <ul className="settings__links">
-          <li>
-            <Link to="/settings/reveal-seed">Reveal</Link>
-          </li>
-        </ul>
-        <div className="settings__section-head">Reset your account</div>
-        <ul className="settings__links">
-          <li>
-            <Link to="/settings/new-wallet">Create a new wallet</Link>
-          </li>
-        </ul>
-        <div className="settings__section-head">HSD API Key</div>
-        <input type="text" className="settings__copy-api-key" value={this.props.apiKey} readOnly />
         <Switch>
           <Route path="/settings/account-index" component={AccountIndexModal} />
           <Route
@@ -93,6 +106,7 @@ export default class Settings extends Component {
             )}
           />
           <Route path="/settings/reveal-seed" component={RevealSeedModal} />
+          <Route path="/settings/zap-txs" component={ZapTXsModal} />
         </Switch>
       </ContentArea>
     );

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -32,12 +32,13 @@ export default class Settings extends Component {
 
   onDownload = async () => {
     try {
-      const content = await logger.download();
+      const {network} = this.props;
+      const content = await logger.download(network);
       const csvContent = `data:text/log;charset=utf-8,${content}\r\n`;
       const encodedUri = encodeURI(csvContent);
       const link = document.createElement('a');
       link.setAttribute('href', encodedUri);
-      link.setAttribute('download', 'bob-debug.log');
+      link.setAttribute('download', `bob-debug-${network}.log`);
       document.body.appendChild(link); // Required for FF
       link.click();
       link.remove();

--- a/app/pages/Settings/index.scss
+++ b/app/pages/Settings/index.scss
@@ -12,6 +12,13 @@
   margin-bottom: 36px;
 }
 
+.settings__supersection {
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 21px;
+  margin-bottom: 3px;
+}
+
 .settings__section-head {
   font-weight: 600;
   font-size: 18px;
@@ -67,4 +74,8 @@
     border-color: $azure-blue;
     outline: 0;
   }
+}
+
+.settings__separator {
+  border: 1px solid $athens-gray;
 }

--- a/app/pages/Settings/zap-txs-modal.scss
+++ b/app/pages/Settings/zap-txs-modal.scss
@@ -1,0 +1,38 @@
+@import '../../variables';
+
+.zap-txs-modal {
+
+  &__checkbox {
+    overflow: auto;
+    margin-bottom: 16px;
+    display: flex;
+    padding-top: 10px;
+  }
+
+  &__checkbox-label {
+    font-size: 14px;
+    color: #909095;
+    font-weight: 500;
+    line-height: 18px;
+    padding-left: 10px;
+    text-align: left;
+    width: 100%;
+  }
+
+  &__tx-list {
+    overflow-y: auto;
+    max-height: 15rem;
+  }
+
+  &__checkbox-box {
+
+  }
+
+  &__action {
+    @extend %btn-primary;
+  }
+}
+
+.wide {
+  width: 100%;
+}

--- a/app/utils/logClient.js
+++ b/app/utils/logClient.js
@@ -18,6 +18,6 @@ export const log = () => {
   logClient.info(...arguments);
 };
 
-export const download = async () => {
-  return await logClient.download();
+export const download = async (network) => {
+  return await logClient.download(network);
 };


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/106

### Changes summary

- Added `zap` to walletClient HTTP calls, hard-coded `age = 1 second` to wipe all.
- Introduce modal that lists unconfirmed TXs with "approve this disclaimer" checkbox and button to delete ("zap") unconfirmed transactions in the wallet.
- Rearranged Settings tab into "wallet actions" and "advanced" sections, cleaned up text
- Bug fix: `walletActions.nameByHash()` was returning `(unknown)` for the name in unconfirmed OPEN covenants. This data is committed in the covenant itself.
- Minor
  - Add `disabled` prop to `Checkbox`
  - Add `wide` prop to `MiniModal`

### New Settings tab layout

![settings-tab](https://user-images.githubusercontent.com/2084648/78362176-a9524f80-7587-11ea-9f57-179f82f6f468.png)

### Delete unconfirmed transactions modal

![delete-txs-modal](https://user-images.githubusercontent.com/2084648/78362201-b53e1180-7587-11ea-8b7f-f9651675494b.png)


