### PR TITLE
Switch bcrypto backend to native

### DIFF
--- a/app/hsdMain.js
+++ b/app/hsdMain.js
@@ -1,9 +1,5 @@
 require('./sentry');
 
-// Need this to force bcrypto to use
-// the JavaScript backend since native
-// bindings are unsupported in Electron.
-process.env.NODE_BACKEND = 'js';
 const ipc = require('electron').ipcRenderer;
 const FullNode = require('hsd/lib/node/fullnode');
 const WalletPlugin = require('hsd/lib/wallet/plugin');

--- a/app/main.js
+++ b/app/main.js
@@ -19,11 +19,6 @@ if (
 }
 
 app.on('ready', async () => {
-  // Need this to force bcrypto to use
-  // the JavaScript backend since native
-  // bindings are unsupported in Electron.
-  process.env.NODE_BACKEND = 'js';
-
   // start the IPC server
   const dbService = require('./background/db/service');
   try {


### PR DESCRIPTION
Address: https://github.com/kyokan/bob-wallet/issues/109
See: https://github.com/bcoin-org/bcrypto/issues/15#issuecomment-611657039
and: https://github.com/bcoin-org/bcrypto#implementations

I don't think this is an issue any more, since libtorsion has now replaced almost all openssl functionality in bcrypto. The only remaining usage of openssl is in `aes` and `random`. And by openssl what I really mean is whatever electron uses for `require('crypto')`

This patch runs fine in dev mode. I also ran the build for OSX and launched the binary with a clean datadir. There were zero issues syncing the mainnet blockchain. I'll do a benchmark comparison in a follow up comment.