### PR TITLE
Use modified WorkerPool module to spawn hsd worker processes

### DIFF
--- a/app/workers/child.js
+++ b/app/workers/child.js
@@ -1,0 +1,193 @@
+/*!
+ * child.js - child processes for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const EventEmitter = require('events');
+const path = require('path');
+const cp = require('child_process');
+
+const children = new Set();
+
+let exitBound = false;
+
+/**
+ * Child
+ * Represents a child process.
+ * @alias module:workers.Child
+ * @extends EventEmitter
+ * @ignore
+ */
+
+class Child extends EventEmitter {
+  /**
+   * Represents a child process.
+   * @constructor
+   * @param {String} file
+   */
+
+  constructor(file) {
+    super();
+
+    bindExit();
+    children.add(this);
+
+    this.init(file);
+  }
+
+  /**
+   * Test whether child process support is available.
+   * @returns {Boolean}
+   */
+
+  static hasSupport() {
+    return true;
+  }
+
+  /**
+   * Initialize child process (node.js).
+   * @private
+   * @param {String} file
+   */
+
+  init(file) {
+    const filename = path.resolve(__dirname, file);
+    const options = { stdio: 'pipe', env: process.env };
+
+    this.child = cp.fork(filename, options);
+
+    this.child.unref();
+    this.child.stdin.unref();
+    this.child.stdout.unref();
+    this.child.stderr.unref();
+
+    this.child.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.child.once('exit', (code, signal) => {
+      children.delete(this);
+      this.emit('exit', code == null ? -1 : code, signal);
+    });
+
+    this.child.stdin.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.child.stdout.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.child.stderr.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.child.stdout.on('data', (data) => {
+      this.emit('data', data);
+    });
+  }
+
+  /**
+   * Send data to child process.
+   * @param {Buffer} data
+   * @returns {Boolean}
+   */
+
+  write(data) {
+    return this.child.stdin.write(data);
+  }
+
+  /**
+   * Destroy the child process.
+   */
+
+  destroy() {
+    this.child.kill('SIGTERM');
+  }
+}
+
+/**
+ * Cleanup all child processes.
+ * @private
+ */
+
+function bindExit() {
+  if (exitBound)
+    return;
+
+  exitBound = true;
+
+  listenExit(() => {
+    for (const child of children)
+      child.destroy();
+  });
+}
+
+/**
+ * Listen for exit.
+ * @param {Function} handler
+ * @private
+ */
+
+function listenExit(handler) {
+  const onSighup = () => {
+    process.exit(1 | 0x80);
+  };
+
+  const onSigint = () => {
+    process.exit(2 | 0x80);
+  };
+
+  const onSigterm = () => {
+    process.exit(15 | 0x80);
+  };
+
+  const onError = (err) => {
+    if (err && err.stack)
+      console.error(String(err.stack));
+    else
+      console.error(String(err));
+
+    process.exit(1);
+  };
+
+  process.once('exit', handler);
+
+  if (process.listenerCount('SIGHUP') === 0)
+    process.once('SIGHUP', onSighup);
+
+  if (process.listenerCount('SIGINT') === 0)
+    process.once('SIGINT', onSigint);
+
+  if (process.listenerCount('SIGTERM') === 0)
+    process.once('SIGTERM', onSigterm);
+
+  if (process.listenerCount('uncaughtException') === 0)
+    process.once('uncaughtException', onError);
+
+  process.on('newListener', (name) => {
+    switch (name) {
+      case 'SIGHUP':
+        process.removeListener(name, onSighup);
+        break;
+      case 'SIGINT':
+        process.removeListener(name, onSigint);
+        break;
+      case 'SIGTERM':
+        process.removeListener(name, onSigterm);
+        break;
+      case 'uncaughtException':
+        process.removeListener(name, onError);
+        break;
+    }
+  });
+}
+
+/*
+ * Expose
+ */
+
+module.exports = Child;

--- a/app/workers/framer.js
+++ b/app/workers/framer.js
@@ -1,0 +1,47 @@
+/*!
+ * workers.js - worker processes for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const bio = require('bufio');
+
+/**
+ * Framer
+ * @alias module:workers.Framer
+ */
+
+class Framer {
+  /**
+   * Create a framer.
+   * @constructor
+   */
+
+  constructor() {}
+
+  packet(payload) {
+    const size = 10 + payload.getSize();
+    const bw = bio.write(size);
+
+    bw.writeU32(payload.id);
+    bw.writeU8(payload.cmd);
+    bw.seek(4);
+
+    payload.write(bw);
+
+    bw.writeU8(0x0a);
+
+    const msg = bw.render();
+    msg.writeUInt32LE(msg.length - 10, 5, true);
+
+    return msg;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = Framer;

--- a/app/workers/index.js
+++ b/app/workers/index.js
@@ -1,0 +1,17 @@
+/*!
+ * workers/index.js - workers for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+/**
+ * @module workers
+ */
+
+exports.Framer = require('./framer');
+exports.jobs = require('./jobs');
+exports.packets = require('./packets');
+exports.Parser = require('./parser');
+exports.WorkerPool = require('./workerpool');

--- a/app/workers/jobs.js
+++ b/app/workers/jobs.js
@@ -1,0 +1,191 @@
+/*!
+ * jobs.js - worker jobs for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const secp256k1 = require('bcrypto/lib/secp256k1');
+const {derive} = require('bcrypto/lib/scrypt');
+const _mine = require('hsd/lib/mining/mine');
+const packets = require('./packets');
+
+/**
+ * @exports workers/jobs
+ */
+
+const jobs = exports;
+
+/**
+ * Execute a job on the worker.
+ * @param {String} cmd
+ * @param {Array} args
+ * @returns {Object}
+ * @throws on unknown command
+ */
+
+jobs.execute = function execute(p) {
+  try {
+    return jobs.handle(p);
+  } catch (e) {
+    return new packets.ErrorResultPacket(e);
+  }
+};
+
+/**
+ * Execute a job on the worker.
+ * @param {String} cmd
+ * @param {Array} args
+ * @returns {Object}
+ * @throws on unknown command
+ */
+
+jobs.handle = function handle(p) {
+  switch (p.cmd) {
+    case packets.types.CHECK:
+      return jobs.check(p.tx, p.view, p.flags);
+    case packets.types.CHECKINPUT:
+      return jobs.checkInput(p.tx, p.index, p.coin, p.flags);
+    case packets.types.SIGN:
+      return jobs.sign(p.tx, p.rings, p.type);
+    case packets.types.SIGNINPUT:
+      return jobs.signInput(p.tx, p.index, p.coin, p.ring, p.type);
+    case packets.types.ECVERIFY:
+      return jobs.ecVerify(p.msg, p.sig, p.key);
+    case packets.types.ECSIGN:
+      return jobs.ecSign(p.msg, p.key);
+    case packets.types.MINE:
+      return jobs.mine(p.hdr, p.target, p.rounds, p.params);
+    case packets.types.SCRYPT:
+      return jobs.scrypt(p.passwd, p.salt, p.N, p.r, p.p, p.len);
+    default:
+      throw new Error(`Unknown command: "${p.cmd}".`);
+  }
+};
+
+/**
+ * Execute tx.check() on worker.
+ * @see TX#check
+ * @param {TX} tx
+ * @param {CoinView} view
+ * @param {VerifyFlags} flags
+ * @returns {CheckResultPacket}
+ */
+
+jobs.check = function check(tx, view, flags) {
+  try {
+    tx.check(view, flags);
+  } catch (err) {
+    if (err.type === 'ScriptError')
+      return new packets.CheckResultPacket(err);
+    throw err;
+  }
+  return new packets.CheckResultPacket();
+};
+
+/**
+ * Execute tx.checkInput() on worker.
+ * @see TX#checkInput
+ * @param {TX} tx
+ * @param {Number} index
+ * @param {Output} coin
+ * @param {VerifyFlags} flags
+ * @returns {CheckInputResultPacket}
+ */
+
+jobs.checkInput = function checkInput(tx, index, coin, flags) {
+  try {
+    tx.checkInput(index, coin, flags);
+  } catch (err) {
+    if (err.type === 'ScriptError')
+      return new packets.CheckInputResultPacket(err);
+    throw err;
+  }
+  return new packets.CheckInputResultPacket();
+};
+
+/**
+ * Execute tx.sign() on worker.
+ * @see MTX#sign
+ * @param {MTX} tx
+ * @param {KeyRing[]} ring
+ * @param {SighashType} type
+ */
+
+jobs.sign = function sign(tx, ring, type) {
+  const total = tx.sign(ring, type);
+  return packets.SignResultPacket.fromTX(tx, total);
+};
+
+/**
+ * Execute tx.signInput() on worker.
+ * @see MTX#signInput
+ * @param {MTX} tx
+ * @param {Number} index
+ * @param {Output} coin
+ * @param {KeyRing} ring
+ * @param {SighashType} type
+ */
+
+jobs.signInput = function signInput(tx, index, coin, ring, type) {
+  const result = tx.signInput(tx, index, coin, ring, type);
+  return packets.SignInputResultPacket.fromTX(tx, index, result);
+};
+
+/**
+ * Execute secp256k1.verify() on worker.
+ * @see secp256k1.verify
+ * @param {TX} tx
+ * @param {VerifyFlags} flags
+ * @returns {Boolean}
+ */
+
+jobs.ecVerify = function ecVerify(msg, sig, key) {
+  const result = secp256k1.verify(msg, sig, key);
+  return new packets.ECVerifyResultPacket(result);
+};
+
+/**
+ * Execute secp256k1.sign() on worker.
+ * @see secp256k1.sign
+ * @param {TX} tx
+ * @param {Number} index
+ * @param {VerifyFlags} flags
+ * @returns {Boolean}
+ */
+
+jobs.ecSign = function ecSign(msg, key) {
+  const sig = secp256k1.sign(msg, key);
+  return new packets.ECSignResultPacket(sig);
+};
+
+/**
+ * Mine a block on worker.
+ * @param {Buffer} hdr
+ * @param {Buffer} target
+ * @param {Number} rounds
+ * @returns {Number}
+ */
+
+jobs.mine = function mine(hdr, target, rounds) {
+  const [nonce, solved] = _mine(hdr, target, rounds);
+  return new packets.MineResultPacket(nonce, solved);
+};
+
+/**
+ * Execute scrypt() on worker.
+ * @see scrypt
+ * @param {Buffer} passwd
+ * @param {Buffer} salt
+ * @param {Number} N
+ * @param {Number} r
+ * @param {Number} p
+ * @param {Number} len
+ * @returns {Buffer}
+ */
+
+jobs.scrypt = function scrypt(passwd, salt, N, r, p, len) {
+  const key = derive(passwd, salt, N, r, p, len);
+  return new packets.ScryptResultPacket(key);
+};

--- a/app/workers/master.js
+++ b/app/workers/master.js
@@ -1,0 +1,198 @@
+/*!
+ * master.js - master process for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const EventEmitter = require('events');
+const {format} = require('util');
+const Network = require('hsd/lib/protocol/network');
+const jobs = require('./jobs');
+const Parser = require('./parser');
+const Framer = require('./framer');
+const packets = require('./packets');
+const Parent = require('./parent');
+const ownership = require('hsd/lib/covenants/ownership');
+
+/**
+ * Master
+ * Represents the master process.
+ * @alias module:workers.Master
+ * @extends EventEmitter
+ */
+
+class Master extends EventEmitter {
+  /**
+   * Create the master process.
+   * @constructor
+   */
+
+  constructor() {
+    super();
+
+    this.parent = new Parent();
+    this.framer = new Framer();
+    this.parser = new Parser();
+    this.listening = false;
+    this.color = false;
+
+    this.init();
+  }
+
+  /**
+   * Initialize master. Bind events.
+   * @private
+   */
+
+  init() {
+    this.parent.on('data', (data) => {
+      this.parser.feed(data);
+    });
+
+    this.parent.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.parent.on('exception', (err) => {
+      this.send(new packets.ErrorPacket(err));
+      setTimeout(() => this.destroy(), 1000);
+    });
+
+    this.parser.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.parser.on('packet', (packet) => {
+      this.emit('packet', packet);
+    });
+  }
+
+  /**
+   * Set environment.
+   * @param {Object} env
+   */
+
+  setEnv(env) {
+    this.color = env.HSD_WORKER_ISTTY === '1';
+    this.set(env.HSD_WORKER_NETWORK);
+    ownership.ignore = env.HSD_WORKER_IGNORE === '1';
+  }
+
+  /**
+   * Set primary network.
+   * @param {NetworkType|Network} network
+   */
+
+  set(network) {
+    return Network.set(network);
+  }
+
+  /**
+   * Send data to worker.
+   * @param {Buffer} data
+   * @returns {Boolean}
+   */
+
+  write(data) {
+    return this.parent.write(data);
+  }
+
+  /**
+   * Frame and send a packet.
+   * @param {Packet} packet
+   * @returns {Boolean}
+   */
+
+  send(packet) {
+    return this.write(this.framer.packet(packet));
+  }
+
+  /**
+   * Emit an event on the worker side.
+   * @param {String} event
+   * @param {...Object} arg
+   * @returns {Boolean}
+   */
+
+  sendEvent(...items) {
+    return this.send(new packets.EventPacket(items));
+  }
+
+  /**
+   * Destroy the worker.
+   */
+
+  destroy() {
+    return this.parent.destroy();
+  }
+
+  /**
+   * Write a message to stdout in the master process.
+   * @param {Object|String} obj
+   * @param {...String} args
+   */
+
+  log() {
+    const text = format.apply(null, arguments);
+    this.send(new packets.LogPacket(text));
+  }
+
+  /**
+   * Listen for messages from master process (only if worker).
+   */
+
+  listen() {
+    assert(!this.listening, 'Already listening.');
+
+    this.listening = true;
+
+    this.on('error', (err) => {
+      this.send(new packets.ErrorPacket(err));
+    });
+
+    this.on('packet', (packet) => {
+      try {
+        this.handlePacket(packet);
+      } catch (e) {
+        this.emit('error', e);
+      }
+    });
+  }
+
+  /**
+   * Handle packet.
+   * @private
+   * @param {Packet}
+   */
+
+  handlePacket(packet) {
+    let result;
+
+    switch (packet.cmd) {
+      case packets.types.ENV:
+        this.setEnv(packet.env);
+        break;
+      case packets.types.EVENT:
+        this.emit('event', packet.items);
+        this.emit(...packet.items);
+        break;
+      case packets.types.ERROR:
+        this.emit('error', packet.error);
+        break;
+      default:
+        result = jobs.execute(packet);
+        result.id = packet.id;
+        this.send(result);
+        break;
+    }
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = Master;

--- a/app/workers/packets.js
+++ b/app/workers/packets.js
@@ -1,0 +1,948 @@
+/*!
+ * packets.js - worker packets for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+/**
+ * @module workers/packets
+ */
+
+const assert = require('bsert');
+const bio = require('bufio');
+const Witness = require('hsd/lib/script/witness');
+const Output = require('hsd/lib/primitives/output');
+const MTX = require('hsd/lib/primitives/mtx');
+const TX = require('hsd/lib/primitives/tx');
+const KeyRing = require('hsd/lib/primitives/keyring');
+const CoinView = require('hsd/lib/coins/coinview');
+const ScriptError = require('hsd/lib/script/scripterror');
+const {encoding} = bio;
+
+/*
+ * Constants
+ */
+
+const packetTypes = {
+  ENV: 0,
+  EVENT: 1,
+  LOG: 2,
+  ERROR: 3,
+  ERRORRESULT: 4,
+  CHECK: 5,
+  CHECKRESULT: 6,
+  SIGN: 7,
+  SIGNRESULT: 8,
+  CHECKINPUT: 9,
+  CHECKINPUTRESULT: 10,
+  SIGNINPUT: 11,
+  SIGNINPUTRESULT: 12,
+  ECVERIFY: 13,
+  ECVERIFYRESULT: 14,
+  ECSIGN: 15,
+  ECSIGNRESULT: 16,
+  MINE: 17,
+  MINERESULT: 18,
+  SCRYPT: 19,
+  SCRYPTRESULT: 20
+};
+
+/**
+ * Packet
+ */
+
+class Packet extends bio.Struct {
+  constructor() {
+    super();
+    this.id = ++Packet.id >>> 0;
+    this.cmd = -1;
+  }
+
+  getSize() {
+    throw new Error('Abstract method.');
+  }
+
+  write(bw) {
+    throw new Error('Abstract method.');
+  }
+
+  read(br) {
+    throw new Error('Abstract method.');
+  }
+
+  decode(data, extra) {
+    const br = bio.read(data, true);
+    this.read(br, extra);
+    return this;
+  }
+}
+
+Packet.id = 0;
+
+/**
+ * EnvPacket
+ */
+
+class EnvPacket extends Packet {
+  constructor(env) {
+    super();
+    this.cmd = packetTypes.ENV;
+    this.env = env || {};
+    this.json = JSON.stringify(this.env);
+  }
+
+  getSize() {
+    return encoding.sizeVarString(this.json, 'utf8');
+  }
+
+  write(bw) {
+    bw.writeVarString(this.json, 'utf8');
+    return bw;
+  }
+
+  read(br) {
+    this.json = br.readVarString('utf8');
+    this.env = JSON.parse(this.json);
+    return this;
+  }
+}
+
+/**
+ * EventPacket
+ */
+
+class EventPacket extends Packet {
+  constructor(items) {
+    super();
+    this.cmd = packetTypes.EVENT;
+    this.items = items || [];
+    this.json = JSON.stringify(this.items);
+  }
+
+  getSize() {
+    return encoding.sizeVarString(this.json, 'utf8');
+  }
+
+  write(bw) {
+    bw.writeVarString(this.json, 'utf8');
+    return bw;
+  }
+
+  read(br) {
+    this.json = br.readVarString('utf8');
+    this.items = JSON.parse(this.json);
+    return this;
+  }
+}
+
+/**
+ * LogPacket
+ */
+
+class LogPacket extends Packet {
+  constructor(text) {
+    super();
+    this.cmd = packetTypes.LOG;
+    this.text = text || '';
+  }
+
+  getSize() {
+    return encoding.sizeVarString(this.text, 'utf8');
+  }
+
+  write(bw) {
+    bw.writeVarString(this.text, 'utf8');
+    return bw;
+  }
+
+  read(br) {
+    this.text = br.readVarString('utf8');
+    return this;
+  }
+}
+
+/**
+ * ErrorPacket
+ */
+
+class ErrorPacket extends Packet {
+  constructor(error) {
+    super();
+    this.cmd = packetTypes.ERROR;
+    this.error = error || new Error();
+  }
+
+  getSize() {
+    const err = this.error;
+
+    let size = 0;
+
+    size += encoding.sizeVarString(stringify(err.message), 'utf8');
+    size += encoding.sizeVarString(stringify(err.stack), 'utf8');
+    size += encoding.sizeVarString(stringify(err.type), 'utf8');
+
+    switch (typeof err.code) {
+      case 'number':
+        size += 1;
+        size += 4;
+        break;
+      case 'string':
+        size += 1;
+        size += encoding.sizeVarString(err.code, 'utf8');
+        break;
+      default:
+        size += 1;
+        break;
+    }
+
+    return size;
+  }
+
+  write(bw) {
+    const err = this.error;
+
+    bw.writeVarString(stringify(err.message), 'utf8');
+    bw.writeVarString(stringify(err.stack), 'utf8');
+    bw.writeVarString(stringify(err.type), 'utf8');
+
+    switch (typeof err.code) {
+      case 'number':
+        bw.writeU8(2);
+        bw.writeI32(err.code);
+        break;
+      case 'string':
+        bw.writeU8(1);
+        bw.writeVarString(err.code, 'utf8');
+        break;
+      default:
+        bw.writeU8(0);
+        break;
+    }
+
+    return bw;
+  }
+
+  read(br) {
+    const err = this.error;
+
+    err.message = br.readVarString('utf8');
+    err.stack = br.readVarString('utf8');
+    err.type = br.readVarString('utf8');
+
+    switch (br.readU8()) {
+      case 2:
+        err.code = br.readI32();
+        break;
+      case 1:
+        err.code = br.readVarString('utf8');
+        break;
+      default:
+        err.code = null;
+        break;
+    }
+
+    return this;
+  }
+}
+
+/**
+ * ErrorResultPacket
+ */
+
+class ErrorResultPacket extends ErrorPacket {
+  constructor(error) {
+    super(error);
+    this.cmd = packetTypes.ERRORRESULT;
+  }
+}
+
+/**
+ * CheckPacket
+ */
+
+class CheckPacket extends Packet {
+  constructor(tx, view, flags) {
+    super();
+    this.cmd = packetTypes.CHECK;
+    this.tx = tx || null;
+    this.view = view || null;
+    this.flags = flags != null ? flags : null;
+  }
+
+  getSize() {
+    return this.tx.getSize() + this.view.getSize(this.tx) + 4;
+  }
+
+  write(bw) {
+    this.tx.write(bw);
+    this.view.write(bw, this.tx);
+    bw.writeI32(this.flags != null ? this.flags : -1);
+    return bw;
+  }
+
+  read(br) {
+    this.tx = TX.read(br);
+    this.view = CoinView.read(br, this.tx);
+    this.flags = br.readI32();
+
+    if (this.flags === -1)
+      this.flags = null;
+
+    return this;
+  }
+}
+
+/**
+ * CheckResultPacket
+ */
+
+class CheckResultPacket extends Packet {
+  constructor(error) {
+    super();
+    this.cmd = packetTypes.CHECKRESULT;
+    this.error = error || null;
+  }
+
+  getSize() {
+    const err = this.error;
+
+    let size = 0;
+
+    if (!err) {
+      size += 1;
+      return size;
+    }
+
+    size += 1;
+    size += encoding.sizeVarString(stringify(err.message), 'utf8');
+    size += encoding.sizeVarString(stringify(err.stack), 'utf8');
+    size += encoding.sizeVarString(stringify(err.code), 'utf8');
+    size += 1;
+    size += 4;
+
+    return size;
+  }
+
+  write(bw) {
+    const err = this.error;
+
+    if (!err) {
+      bw.writeU8(0);
+      return bw;
+    }
+
+    bw.writeU8(1);
+    bw.writeVarString(stringify(err.message), 'utf8');
+    bw.writeVarString(stringify(err.stack), 'utf8');
+    bw.writeVarString(stringify(err.code), 'utf8');
+    bw.writeU8(err.op === -1 ? 0xff : err.op);
+    bw.writeU32(err.ip === -1 ? 0xffffffff : err.ip);
+
+    return bw;
+  }
+
+  read(br) {
+    if (br.readU8() === 0)
+      return this;
+
+    const err = new ScriptError('');
+
+    err.message = br.readVarString('utf8');
+    err.stack = br.readVarString('utf8');
+    err.code = br.readVarString('utf8');
+    err.op = br.readU8();
+    err.ip = br.readU32();
+
+    if (err.op === 0xff)
+      err.op = -1;
+
+    if (err.ip === 0xffffffff)
+      err.ip = -1;
+
+    this.error = err;
+
+    return this;
+  }
+}
+
+/**
+ * SignPacket
+ */
+
+class SignPacket extends Packet {
+  constructor(tx, rings, type) {
+    super();
+    this.cmd = packetTypes.SIGN;
+    this.tx = tx || null;
+    this.rings = rings || [];
+    this.type = type != null ? type : 1;
+  }
+
+  getSize() {
+    let size = 0;
+
+    size += this.tx.getSize();
+    size += this.tx.view.getSize(this.tx);
+    size += encoding.sizeVarint(this.rings.length);
+
+    for (const ring of this.rings)
+      size += ring.getSize();
+
+    size += 1;
+
+    return size;
+  }
+
+  write(bw) {
+    this.tx.write(bw);
+    this.tx.view.write(bw, this.tx);
+
+    bw.writeVarint(this.rings.length);
+
+    for (const ring of this.rings)
+      ring.write(bw);
+
+    bw.writeU8(this.type);
+
+    return bw;
+  }
+
+  read(br) {
+    this.tx = MTX.read(br);
+    this.tx.view.read(br, this.tx);
+
+    const count = br.readVarint();
+
+    for (let i = 0; i < count; i++) {
+      const ring = KeyRing.read(br);
+      this.rings.push(ring);
+    }
+
+    this.type = br.readU8();
+
+    return this;
+  }
+}
+
+/**
+ * SignResultPacket
+ */
+
+class SignResultPacket extends Packet {
+  constructor(total, witness, script) {
+    super();
+    this.cmd = packetTypes.SIGNRESULT;
+    this.total = total || 0;
+    this.witness = witness || [];
+  }
+
+  fromTX(tx, total) {
+    this.total = total;
+
+    for (const input of tx.inputs)
+      this.witness.push(input.witness);
+
+    return this;
+  }
+
+  static fromTX(tx, total) {
+    return new SignResultPacket().fromTX(tx, total);
+  }
+
+  getSize() {
+    let size = 0;
+
+    size += encoding.sizeVarint(this.total);
+    size += encoding.sizeVarint(this.witness.length);
+
+    for (let i = 0; i < this.witness.length; i++) {
+      const witness = this.witness[i];
+      size += witness.getVarSize();
+    }
+
+    return size;
+  }
+
+  write(bw) {
+    bw.writeVarint(this.total);
+    bw.writeVarint(this.witness.length);
+
+    for (let i = 0; i < this.witness.length; i++)
+      this.witness[i].write(bw);
+
+    return bw;
+  }
+
+  inject(tx) {
+    assert(this.witness.length === tx.inputs.length);
+
+    for (let i = 0; i < tx.inputs.length; i++) {
+      const input = tx.inputs[i];
+      input.witness = this.witness[i];
+    }
+  }
+
+  read(br) {
+    this.total = br.readVarint();
+
+    const count = br.readVarint();
+
+    for (let i = 0; i < count; i++)
+      this.witness.push(Witness.read(br));
+
+    return this;
+  }
+}
+
+/**
+ * CheckInputPacket
+ */
+
+class CheckInputPacket extends Packet {
+  constructor(tx, index, coin, flags) {
+    super();
+    this.cmd = packetTypes.CHECKINPUT;
+    this.tx = tx || null;
+    this.index = index;
+    this.coin = coin || null;
+    this.flags = flags != null ? flags : null;
+  }
+
+  getSize() {
+    let size = 0;
+    size += this.tx.getSize();
+    size += encoding.sizeVarint(this.index);
+    size += encoding.sizeVarint(this.coin.value);
+    size += this.coin.script.getVarSize();
+    size += 4;
+    return size;
+  }
+
+  write(bw) {
+    this.tx.write(bw);
+    bw.writeVarint(this.index);
+    bw.writeVarint(this.coin.value);
+    this.coin.script.write(bw);
+    bw.writeI32(this.flags != null ? this.flags : -1);
+    return bw;
+  }
+
+  read(br) {
+    this.tx = TX.read(br);
+    this.index = br.readVarint();
+
+    this.coin = new Output();
+    this.coin.value = br.readVarint();
+    this.coin.script.read(br);
+
+    this.flags = br.readI32();
+
+    if (this.flags === -1)
+      this.flags = null;
+
+    return this;
+  }
+}
+
+/**
+ * CheckInputResultPacket
+ */
+
+class CheckInputResultPacket extends CheckResultPacket {
+  constructor(error) {
+    super(error);
+    this.cmd = packetTypes.CHECKINPUTRESULT;
+  }
+}
+
+/**
+ * SignInputPacket
+ */
+
+class SignInputPacket extends Packet {
+  constructor(tx, index, coin, ring, type) {
+    super();
+    this.cmd = packetTypes.SIGNINPUT;
+    this.tx = tx || null;
+    this.index = index;
+    this.coin = coin || null;
+    this.ring = ring || null;
+    this.type = type != null ? type : 1;
+  }
+
+  getSize() {
+    let size = 0;
+    size += this.tx.getSize();
+    size += encoding.sizeVarint(this.index);
+    size += encoding.sizeVarint(this.coin.value);
+    size += this.coin.script.getVarSize();
+    size += this.ring.getSize();
+    size += 1;
+    return size;
+  }
+
+  write(bw) {
+    this.tx.write(bw);
+    bw.writeVarint(this.index);
+    bw.writeVarint(this.coin.value);
+    this.coin.script.write(bw);
+    this.ring.write(bw);
+    bw.writeU8(this.type);
+    return bw;
+  }
+
+  read(br) {
+    this.tx = MTX.read(br);
+    this.index = br.readVarint();
+
+    this.coin = new Output();
+    this.coin.value = br.readVarint();
+    this.coin.script.read(br);
+
+    this.ring = KeyRing.read(br);
+    this.type = br.readU8();
+
+    return this;
+  }
+}
+
+/**
+ * SignInputResultPacket
+ */
+
+class SignInputResultPacket extends Packet {
+  constructor(value, witness) {
+    super();
+    this.cmd = packetTypes.SIGNINPUTRESULT;
+    this.value = value || false;
+    this.witness = witness || null;
+  }
+
+  fromTX(tx, i, value) {
+    const input = tx.inputs[i];
+
+    assert(input);
+
+    this.value = value;
+    this.witness = input.witness;
+
+    return this;
+  }
+
+  static fromTX(tx, i, value) {
+    return new SignInputResultPacket().fromTX(tx, i, value);
+  }
+
+  getSize() {
+    return 1 + this.witness.getVarSize();
+  }
+
+  write(bw) {
+    bw.writeU8(this.value ? 1 : 0);
+    this.witness.write(bw);
+    return bw;
+  }
+
+  inject(tx, i) {
+    const input = tx.inputs[i];
+    assert(input);
+    input.witness = this.witness;
+  }
+
+  read(br) {
+    this.value = br.readU8() === 1;
+    this.witness = Witness.read(br);
+    return this;
+  }
+}
+
+/**
+ * ECVerifyPacket
+ */
+
+class ECVerifyPacket extends Packet {
+  constructor(msg, sig, key) {
+    super();
+    this.cmd = packetTypes.ECVERIFY;
+    this.msg = msg || null;
+    this.sig = sig || null;
+    this.key = key || null;
+  }
+
+  getSize() {
+    let size = 0;
+    size += encoding.sizeVarBytes(this.msg);
+    size += encoding.sizeVarBytes(this.sig);
+    size += encoding.sizeVarBytes(this.key);
+    return size;
+  }
+
+  write(bw) {
+    bw.writeVarBytes(this.msg);
+    bw.writeVarBytes(this.sig);
+    bw.writeVarBytes(this.key);
+    return bw;
+  }
+
+  read(br) {
+    this.msg = br.readVarBytes();
+    this.sig = br.readVarBytes();
+    this.key = br.readVarBytes();
+    return this;
+  }
+}
+
+/**
+ * ECVerifyResultPacket
+ */
+
+class ECVerifyResultPacket extends Packet {
+  constructor(value) {
+    super();
+    this.cmd = packetTypes.ECVERIFYRESULT;
+    this.value = value;
+  }
+
+  getSize() {
+    return 1;
+  }
+
+  write(bw) {
+    bw.writeU8(this.value ? 1 : 0);
+    return bw;
+  }
+
+  read(br) {
+    this.value = br.readU8() === 1;
+    return this;
+  }
+}
+
+/**
+ * ECSignPacket
+ */
+
+class ECSignPacket extends Packet {
+  constructor(msg, key) {
+    super();
+    this.cmd = packetTypes.ECSIGN;
+    this.msg = msg || null;
+    this.key = key || null;
+  }
+
+  getSize() {
+    let size = 0;
+    size += encoding.sizeVarBytes(this.msg);
+    size += encoding.sizeVarBytes(this.key);
+    return size;
+  }
+
+  write(bw) {
+    bw.writeVarBytes(this.msg);
+    bw.writeVarBytes(this.key);
+    return bw;
+  }
+
+  read(br) {
+    this.msg = br.readVarBytes();
+    this.key = br.readVarBytes();
+    return this;
+  }
+}
+
+/**
+ * ECSignResultPacket
+ */
+
+class ECSignResultPacket extends Packet {
+  constructor(sig) {
+    super();
+    this.cmd = packetTypes.ECSIGNRESULT;
+    this.sig = sig;
+  }
+
+  getSize() {
+    return encoding.sizeVarBytes(this.sig);
+  }
+
+  write(bw) {
+    bw.writeVarBytes(this.sig);
+    return bw;
+  }
+
+  read(br) {
+    this.sig = br.readVarBytes();
+    return this;
+  }
+}
+
+/**
+ * MinePacket
+ */
+
+class MinePacket extends Packet {
+  constructor(hdr, target, rounds) {
+    super();
+    this.cmd = packetTypes.MINE;
+    this.hdr = hdr || null;
+    this.target = target || null;
+    this.rounds = rounds != null ? rounds : -1;
+  }
+
+  getSize() {
+    return 256 + 32 + 4;
+  }
+
+  write(bw) {
+    bw.writeBytes(this.hdr);
+    bw.writeBytes(this.target);
+    bw.writeU32(this.rounds);
+    return bw;
+  }
+
+  read(br) {
+    this.hdr = br.readBytes(256);
+    this.target = br.readBytes(32);
+    this.rounds = br.readU32();
+    return this;
+  }
+}
+
+/**
+ * MineResultPacket
+ */
+
+class MineResultPacket extends Packet {
+  constructor(nonce, solved) {
+    super();
+    this.cmd = packetTypes.MINERESULT;
+    this.nonce = nonce || 0;
+    this.solved = solved || false;
+  }
+
+  getSize() {
+    return 4 + 1;
+  }
+
+  write(bw) {
+    bw.writeU32(this.nonce);
+    bw.writeU8(this.solved ? 1 : 0);
+    return bw;
+  }
+
+  read(br) {
+    this.nonce = br.readU32();
+    this.solved = br.readU8() === 1;
+    return this;
+  }
+}
+
+/**
+ * ScryptPacket
+ */
+
+class ScryptPacket extends Packet {
+  constructor(passwd, salt, N, r, p, len) {
+    super();
+    this.cmd = packetTypes.SCRYPT;
+    this.passwd = passwd || null;
+    this.salt = salt || null;
+    this.N = N != null ? N : -1;
+    this.r = r != null ? r : -1;
+    this.p = p != null ? p : -1;
+    this.len = len != null ? len : -1;
+  }
+
+  getSize() {
+    let size = 0;
+    size += encoding.sizeVarBytes(this.passwd);
+    size += encoding.sizeVarBytes(this.salt);
+    size += 16;
+    return size;
+  }
+
+  write(bw) {
+    bw.writeVarBytes(this.passwd);
+    bw.writeVarBytes(this.salt);
+    bw.writeU32(this.N);
+    bw.writeU32(this.r);
+    bw.writeU32(this.p);
+    bw.writeU32(this.len);
+    return bw;
+  }
+
+  read(br) {
+    this.passwd = br.readVarBytes();
+    this.salt = br.readVarBytes();
+    this.N = br.readU32();
+    this.r = br.readU32();
+    this.p = br.readU32();
+    this.len = br.readU32();
+    return this;
+  }
+}
+
+/**
+ * ScryptResultPacket
+ */
+
+class ScryptResultPacket extends Packet {
+  constructor(key) {
+    super();
+    this.cmd = packetTypes.SCRYPTRESULT;
+    this.key = key || null;
+  }
+
+  getSize() {
+    return encoding.sizeVarBytes(this.key);
+  }
+
+  write(bw) {
+    bw.writeVarBytes(this.key);
+    return bw;
+  }
+
+  read(br) {
+    this.key = br.readVarBytes();
+    return this;
+  }
+}
+
+/*
+ * Helpers
+ */
+
+function stringify(value) {
+  if (typeof value !== 'string')
+    return '';
+  return value;
+}
+
+/*
+ * Expose
+ */
+
+exports.types = packetTypes;
+exports.EnvPacket = EnvPacket;
+exports.EventPacket = EventPacket;
+exports.LogPacket = LogPacket;
+exports.ErrorPacket = ErrorPacket;
+exports.ErrorResultPacket = ErrorResultPacket;
+exports.CheckPacket = CheckPacket;
+exports.CheckResultPacket = CheckResultPacket;
+exports.SignPacket = SignPacket;
+exports.SignResultPacket = SignResultPacket;
+exports.CheckInputPacket = CheckInputPacket;
+exports.CheckInputResultPacket = CheckInputResultPacket;
+exports.SignInputPacket = SignInputPacket;
+exports.SignInputResultPacket = SignInputResultPacket;
+exports.ECVerifyPacket = ECVerifyPacket;
+exports.ECVerifyResultPacket = ECVerifyResultPacket;
+exports.ECSignPacket = ECSignPacket;
+exports.ECSignResultPacket = ECSignResultPacket;
+exports.MinePacket = MinePacket;
+exports.MineResultPacket = MineResultPacket;
+exports.ScryptPacket = ScryptPacket;
+exports.ScryptResultPacket = ScryptResultPacket;

--- a/app/workers/parent.js
+++ b/app/workers/parent.js
@@ -1,0 +1,73 @@
+/*!
+ * parent.js - worker processes for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const EventEmitter = require('events');
+
+/**
+ * Parent
+ * Represents the parent process.
+ * @alias module:workers.Parent
+ * @extends EventEmitter
+ */
+
+class Parent extends EventEmitter {
+  /**
+   * Create the parent process.
+   * @constructor
+   */
+
+  constructor() {
+    super();
+
+    this.init();
+  }
+
+  /**
+   * Initialize master (node.js).
+   * @private
+   */
+
+  init() {
+    process.stdin.on('data', (data) => {
+      this.emit('data', data);
+    });
+
+    // Nowhere to send these errors:
+    process.stdin.on('error', () => {});
+    process.stdout.on('error', () => {});
+    process.stderr.on('error', () => {});
+
+    process.on('uncaughtException', (err) => {
+      this.emit('exception', err);
+    });
+  }
+
+  /**
+   * Send data to parent process.
+   * @param {Buffer} data
+   * @returns {Boolean}
+   */
+
+  write(data) {
+    return process.stdout.write(data);
+  }
+
+  /**
+   * Destroy the parent process.
+   */
+
+  destroy() {
+    process.exit(0);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = Parent;

--- a/app/workers/parser.js
+++ b/app/workers/parser.js
@@ -1,0 +1,202 @@
+/*!
+ * parser.js - worker parser for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const EventEmitter = require('events');
+const packets = require('./packets');
+
+/**
+ * Parser
+ * @alias module:workers.Parser
+ * @extends EventEmitter
+ */
+
+class Parser extends EventEmitter {
+  /**
+   * Create a parser.
+   * @constructor
+   */
+
+  constructor() {
+    super();
+
+    this.waiting = 9;
+    this.header = null;
+    this.pending = [];
+    this.total = 0;
+  }
+
+  feed(data) {
+    this.total += data.length;
+    this.pending.push(data);
+
+    while (this.total >= this.waiting) {
+      const chunk = this.read(this.waiting);
+      this.parse(chunk);
+    }
+  }
+
+  read(size) {
+    assert(this.total >= size, 'Reading too much.');
+
+    if (size === 0)
+      return Buffer.alloc(0);
+
+    const pending = this.pending[0];
+
+    if (pending.length > size) {
+      const chunk = pending.slice(0, size);
+      this.pending[0] = pending.slice(size);
+      this.total -= chunk.length;
+      return chunk;
+    }
+
+    if (pending.length === size) {
+      const chunk = this.pending.shift();
+      this.total -= chunk.length;
+      return chunk;
+    }
+
+    const chunk = Buffer.allocUnsafe(size);
+    let off = 0;
+
+    while (off < chunk.length) {
+      const pending = this.pending[0];
+      const len = pending.copy(chunk, off);
+      if (len === pending.length)
+        this.pending.shift();
+      else
+        this.pending[0] = pending.slice(len);
+      off += len;
+    }
+
+    assert.strictEqual(off, chunk.length);
+
+    this.total -= chunk.length;
+
+    return chunk;
+  }
+
+  parse(data) {
+    let header = this.header;
+
+    if (!header) {
+      try {
+        header = this.parseHeader(data);
+      } catch (e) {
+        this.emit('error', e);
+        return;
+      }
+
+      this.header = header;
+      this.waiting = header.size + 1;
+
+      return;
+    }
+
+    this.waiting = 9;
+    this.header = null;
+
+    let packet;
+    try {
+      packet = this.parsePacket(header, data);
+    } catch (e) {
+      this.emit('error', e);
+      return;
+    }
+
+    if (data[data.length - 1] !== 0x0a) {
+      this.emit('error', new Error('No trailing newline.'));
+      return;
+    }
+
+    packet.id = header.id;
+
+    this.emit('packet', packet);
+  }
+
+  parseHeader(data) {
+    const id = data.readUInt32LE(0, true);
+    const cmd = data.readUInt8(4, true);
+    const size = data.readUInt32LE(5, true);
+    return new Header(id, cmd, size);
+  }
+
+  parsePacket(header, data) {
+    switch (header.cmd) {
+      case packets.types.ENV:
+        return packets.EnvPacket.decode(data);
+      case packets.types.EVENT:
+        return packets.EventPacket.decode(data);
+      case packets.types.LOG:
+        return packets.LogPacket.decode(data);
+      case packets.types.ERROR:
+        return packets.ErrorPacket.decode(data);
+      case packets.types.ERRORRESULT:
+        return packets.ErrorResultPacket.decode(data);
+      case packets.types.CHECK:
+        return packets.CheckPacket.decode(data);
+      case packets.types.CHECKRESULT:
+        return packets.CheckResultPacket.decode(data);
+      case packets.types.SIGN:
+        return packets.SignPacket.decode(data);
+      case packets.types.SIGNRESULT:
+        return packets.SignResultPacket.decode(data);
+      case packets.types.CHECKINPUT:
+        return packets.CheckInputPacket.decode(data);
+      case packets.types.CHECKINPUTRESULT:
+        return packets.CheckInputResultPacket.decode(data);
+      case packets.types.SIGNINPUT:
+        return packets.SignInputPacket.decode(data);
+      case packets.types.SIGNINPUTRESULT:
+        return packets.SignInputResultPacket.decode(data);
+      case packets.types.ECVERIFY:
+        return packets.ECVerifyPacket.decode(data);
+      case packets.types.ECVERIFYRESULT:
+        return packets.ECVerifyResultPacket.decode(data);
+      case packets.types.ECSIGN:
+        return packets.ECSignPacket.decode(data);
+      case packets.types.ECSIGNRESULT:
+        return packets.ECSignResultPacket.decode(data);
+      case packets.types.MINE:
+        return packets.MinePacket.decode(data);
+      case packets.types.MINERESULT:
+        return packets.MineResultPacket.decode(data);
+      case packets.types.SCRYPT:
+        return packets.ScryptPacket.decode(data);
+      case packets.types.SCRYPTRESULT:
+        return packets.ScryptResultPacket.decode(data);
+      default:
+        throw new Error('Unknown packet.');
+    }
+  }
+}
+
+/**
+ * Header
+ * @ignore
+ */
+
+class Header {
+  /**
+   * Create a header.
+   * @constructor
+   */
+
+  constructor(id, cmd, size) {
+    this.id = id;
+    this.cmd = cmd;
+    this.size = size;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = Parser;

--- a/app/workers/worker.js
+++ b/app/workers/worker.js
@@ -1,0 +1,14 @@
+/*!
+ * worker.js - worker thread/process for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const Master = require('./master');
+const server = new Master();
+
+process.title = 'hsd-worker';
+
+server.listen();

--- a/app/workers/workerpool.js
+++ b/app/workers/workerpool.js
@@ -1,0 +1,694 @@
+/*!
+ * workerpool.js - worker processes for hsd
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+/* eslint no-nested-ternary: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const EventEmitter = require('events');
+const os = require('os');
+const Network = require('hsd/lib/protocol/network');
+const Child = require('./child');
+const jobs = require('./jobs');
+const Parser = require('./parser');
+const Framer = require('./framer');
+const packets = require('./packets');
+const ownership = require('hsd/lib/covenants/ownership');
+
+/**
+ * Worker Pool
+ * @alias module:workers.WorkerPool
+ * @extends EventEmitter
+ * @property {Number} size
+ * @property {Number} timeout
+ * @property {Map} children
+ * @property {Number} uid
+ */
+
+class WorkerPool extends EventEmitter {
+  /**
+   * Create a worker pool.
+   * @constructor
+   * @param {Object} options
+   * @param {Number} [options.size=num-cores] - Max pool size.
+   * @param {Number} [options.timeout=120000] - Execution timeout.
+   */
+
+  constructor(options) {
+    super();
+
+    this.enabled = false;
+    this.size = getCores();
+    this.timeout = 120000;
+    this.file = process.env.HSD_WORKER_FILE || 'worker.js';
+
+    this.children = new Map();
+    this.uid = 0;
+
+    this.set(options);
+  }
+
+  /**
+   * Set worker pool options.
+   * @param {Object} options
+   */
+
+  set(options) {
+    if (!options)
+      return;
+
+    if (options.enabled != null) {
+      assert(typeof options.enabled === 'boolean');
+      this.enabled = options.enabled;
+    }
+
+    if (options.size != null) {
+      assert((options.size >>> 0) === options.size);
+      assert(options.size > 0);
+      this.size = options.size;
+    }
+
+    if (options.timeout != null) {
+      assert(Number.isSafeInteger(options.timeout));
+      assert(options.timeout >= -1);
+      this.timeout = options.timeout;
+    }
+
+    if (options.file != null) {
+      assert(typeof options.file === 'string');
+      this.file = options.file;
+    }
+  }
+
+  /**
+   * Open worker pool.
+   * @returns {Promise}
+   */
+
+  async open() {
+    ;
+  }
+
+  /**
+   * Close worker pool.
+   * @returns {Promise}
+   */
+
+  async close() {
+    this.destroy();
+  }
+
+  /**
+   * Spawn a new worker.
+   * @param {Number} id - Worker ID.
+   * @returns {Worker}
+   */
+
+  spawn(id) {
+    const child = new Worker(this.file);
+
+    child.id = id;
+
+    child.on('error', (err) => {
+      this.emit('error', err, child);
+    });
+
+    child.on('exit', (code) => {
+      this.emit('exit', code, child);
+
+      if (this.children.get(id) === child)
+        this.children.delete(id);
+    });
+
+    child.on('event', (items) => {
+      this.emit('event', items, child);
+      this.emit(...items);
+    });
+
+    child.on('log', (text) => {
+      this.emit('log', text, child);
+    });
+
+    this.emit('spawn', child);
+
+    return child;
+  }
+
+  /**
+   * Allocate a new worker, will not go above `size` option
+   * and will automatically load balance the workers.
+   * @returns {Worker}
+   */
+
+  alloc() {
+    const id = this.uid++ % this.size;
+
+    if (!this.children.has(id))
+      this.children.set(id, this.spawn(id));
+
+    return this.children.get(id);
+  }
+
+  /**
+   * Emit an event on the worker side (all workers).
+   * @param {String} event
+   * @param {...Object} arg
+   * @returns {Boolean}
+   */
+
+  sendEvent() {
+    let result = true;
+
+    for (const child of this.children.values()) {
+      if (!child.sendEvent.apply(child, arguments))
+        result = false;
+    }
+
+    return result;
+  }
+
+  /**
+   * Destroy all workers.
+   */
+
+  destroy() {
+    for (const child of this.children.values())
+      child.destroy();
+  }
+
+  /**
+   * Call a method for a worker to execute.
+   * @param {Packet} packet
+   * @param {Number} timeout
+   * @returns {Promise}
+   */
+
+  execute(packet, timeout) {
+    if (!this.enabled || !Child.hasSupport()) {
+      return new Promise((resolve, reject) => {
+        setImmediate(() => {
+          let result;
+          try {
+            result = jobs.handle(packet);
+          } catch (e) {
+            reject(e);
+            return;
+          }
+          resolve(result);
+        });
+      });
+    }
+
+    if (!timeout)
+      timeout = this.timeout;
+
+    const child = this.alloc();
+
+    return child.execute(packet, timeout);
+  }
+
+  /**
+   * Execute the tx check job (default timeout).
+   * @method
+   * @param {TX} tx
+   * @param {CoinView} view
+   * @param {VerifyFlags} flags
+   * @returns {Promise}
+   */
+
+  async check(tx, view, flags) {
+    const packet = new packets.CheckPacket(tx, view, flags);
+    const result = await this.execute(packet, -1);
+
+    if (result.error)
+      throw result.error;
+
+    return null;
+  }
+
+  /**
+   * Execute the tx signing job (default timeout).
+   * @method
+   * @param {MTX} tx
+   * @param {KeyRing[]} ring
+   * @param {SighashType} type
+   * @returns {Promise}
+   */
+
+  async sign(tx, ring, type) {
+    let rings = ring;
+
+    if (!Array.isArray(rings))
+      rings = [rings];
+
+    const packet = new packets.SignPacket(tx, rings, type);
+    const result = await this.execute(packet, -1);
+
+    result.inject(tx);
+
+    return result.total;
+  }
+
+  /**
+   * Execute the tx input check job (default timeout).
+   * @method
+   * @param {TX} tx
+   * @param {Number} index
+   * @param {Coin|Output} coin
+   * @param {VerifyFlags} flags
+   * @returns {Promise}
+   */
+
+  async checkInput(tx, index, coin, flags) {
+    const packet = new packets.CheckInputPacket(tx, index, coin, flags);
+    const result = await this.execute(packet, -1);
+
+    if (result.error)
+      throw result.error;
+
+    return null;
+  }
+
+  /**
+   * Execute the tx input signing job (default timeout).
+   * @method
+   * @param {MTX} tx
+   * @param {Number} index
+   * @param {Coin|Output} coin
+   * @param {KeyRing} ring
+   * @param {SighashType} type
+   * @returns {Promise}
+   */
+
+  async signInput(tx, index, coin, ring, type) {
+    const packet = new packets.SignInputPacket(tx, index, coin, ring, type);
+    const result = await this.execute(packet, -1);
+    result.inject(tx);
+    return result.value;
+  }
+
+  /**
+   * Execute the secp256k1 verify job (no timeout).
+   * @method
+   * @param {Buffer} msg
+   * @param {Buffer} sig - DER formatted.
+   * @param {Buffer} key
+   * @returns {Promise}
+   */
+
+  async ecVerify(msg, sig, key) {
+    const packet = new packets.ECVerifyPacket(msg, sig, key);
+    const result = await this.execute(packet, -1);
+    return result.value;
+  }
+
+  /**
+   * Execute the secp256k1 signing job (no timeout).
+   * @method
+   * @param {Buffer} msg
+   * @param {Buffer} key
+   * @returns {Promise}
+   */
+
+  async ecSign(msg, key) {
+    const packet = new packets.ECSignPacket(msg, key);
+    const result = await this.execute(packet, -1);
+    return result.sig;
+  }
+
+  /**
+   * Execute the mining job (no timeout).
+   * @method
+   * @param {Buffer} hdr
+   * @param {Buffer} target
+   * @param {Number} rounds
+   * @returns {Promise} - Returns {Number}.
+   */
+
+  async mine(hdr, target, rounds) {
+    const packet = new packets.MinePacket(hdr, target, rounds);
+    const {nonce, solved} = await this.execute(packet, -1);
+    return [nonce, solved];
+  }
+
+  /**
+   * Execute scrypt job (no timeout).
+   * @method
+   * @param {Buffer} passwd
+   * @param {Buffer} salt
+   * @param {Number} N
+   * @param {Number} r
+   * @param {Number} p
+   * @param {Number} len
+   * @returns {Promise}
+   */
+
+  async scrypt(passwd, salt, N, r, p, len) {
+    const packet = new packets.ScryptPacket(passwd, salt, N, r, p, len);
+    const result = await this.execute(packet, -1);
+    return result.key;
+  }
+}
+
+/**
+ * Worker
+ * @alias module:workers.Worker
+ * @extends EventEmitter
+ */
+
+class Worker extends EventEmitter {
+  /**
+   * Create a worker.
+   * @constructor
+   * @param {String} file
+   */
+
+  constructor(file) {
+    super();
+
+    this.id = -1;
+    this.framer = new Framer();
+    this.parser = new Parser();
+    this.pending = new Map();
+
+    this.child = new Child(file);
+
+    this.init();
+  }
+
+  /**
+   * Initialize worker. Bind to events.
+   * @private
+   */
+
+  init() {
+    this.child.on('data', (data) => {
+      this.parser.feed(data);
+    });
+
+    this.child.on('exit', (code, signal) => {
+      this.emit('exit', code, signal);
+    });
+
+    this.child.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.parser.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    this.parser.on('packet', (packet) => {
+      this.emit('packet', packet);
+    });
+
+    this.listen();
+  }
+
+  /**
+   * Listen for packets.
+   * @private
+   */
+
+  listen() {
+    this.on('exit', (code, signal) => {
+      this.killJobs();
+    });
+
+    this.on('error', (err) => {
+      this.killJobs();
+    });
+
+    this.on('packet', (packet) => {
+      try {
+        this.handlePacket(packet);
+      } catch (e) {
+        this.emit('error', e);
+      }
+    });
+
+    this.sendEnv({
+      HSD_WORKER_NETWORK: Network.type,
+      HSD_WORKER_ISTTY: process.stdout
+        ? (process.stdout.isTTY ? '1' : '0')
+        : '0',
+      HSD_WORKER_IGNORE: ownership.ignore ? '1' : '0'
+    });
+  }
+
+  /**
+   * Handle packet.
+   * @private
+   * @param {Packet} packet
+   */
+
+  handlePacket(packet) {
+    switch (packet.cmd) {
+      case packets.types.EVENT:
+        this.emit('event', packet.items);
+        this.emit(...packet.items);
+        break;
+      case packets.types.LOG:
+        this.emit('log', packet.text);
+        break;
+      case packets.types.ERROR:
+        this.emit('error', packet.error);
+        break;
+      case packets.types.ERRORRESULT:
+        this.rejectJob(packet.id, packet.error);
+        break;
+      default:
+        this.resolveJob(packet.id, packet);
+        break;
+    }
+  }
+
+  /**
+   * Send data to worker.
+   * @param {Buffer} data
+   * @returns {Boolean}
+   */
+
+  write(data) {
+    return this.child.write(data);
+  }
+
+  /**
+   * Frame and send a packet.
+   * @param {Packet} packet
+   * @returns {Boolean}
+   */
+
+  send(packet) {
+    return this.write(this.framer.packet(packet));
+  }
+
+  /**
+   * Send environment.
+   * @param {Object} env
+   * @returns {Boolean}
+   */
+
+  sendEnv(env) {
+    return this.send(new packets.EnvPacket(env));
+  }
+
+  /**
+   * Emit an event on the worker side.
+   * @param {String} event
+   * @param {...Object} arg
+   * @returns {Boolean}
+   */
+
+  sendEvent(...items) {
+    return this.send(new packets.EventPacket(items));
+  }
+
+  /**
+   * Destroy the worker.
+   */
+
+  destroy() {
+    return this.child.destroy();
+  }
+
+  /**
+   * Call a method for a worker to execute.
+   * @param {Packet} packet
+   * @param {Number} timeout
+   * @returns {Promise}
+   */
+
+  execute(packet, timeout) {
+    return new Promise((resolve, reject) => {
+      this._execute(packet, timeout, resolve, reject);
+    });
+  }
+
+  /**
+   * Call a method for a worker to execute.
+   * @private
+   * @param {Packet} packet
+   * @param {Number} timeout
+   * @param {Function} resolve
+   * @param {Function} reject
+   * the worker method specifies.
+   */
+
+  _execute(packet, timeout, resolve, reject) {
+    const job = new PendingJob(this, packet.id, resolve, reject);
+
+    assert(!this.pending.has(packet.id), 'ID overflow.');
+
+    this.pending.set(packet.id, job);
+
+    job.start(timeout);
+
+    this.send(packet);
+  }
+
+  /**
+   * Resolve a job.
+   * @param {Number} id
+   * @param {Packet} result
+   */
+
+  resolveJob(id, result) {
+    const job = this.pending.get(id);
+
+    if (!job)
+      throw new Error(`Job ${id} is not in progress.`);
+
+    job.resolve(result);
+  }
+
+  /**
+   * Reject a job.
+   * @param {Number} id
+   * @param {Error} err
+   */
+
+  rejectJob(id, err) {
+    const job = this.pending.get(id);
+
+    if (!job)
+      throw new Error(`Job ${id} is not in progress.`);
+
+    job.reject(err);
+  }
+
+  /**
+   * Kill all jobs associated with worker.
+   */
+
+  killJobs() {
+    for (const job of this.pending.values())
+      job.destroy();
+  }
+}
+
+/**
+ * Pending Job
+ * @ignore
+ */
+
+class PendingJob {
+  /**
+   * Create a pending job.
+   * @constructor
+   * @param {Worker} worker
+   * @param {Number} id
+   * @param {Function} resolve
+   * @param {Function} reject
+   */
+
+  constructor(worker, id, resolve, reject) {
+    this.worker = worker;
+    this.id = id;
+    this.job = { resolve, reject };
+    this.timer = null;
+  }
+
+  /**
+   * Start the timer.
+   * @param {Number} timeout
+   */
+
+  start(timeout) {
+    if (!timeout || timeout <= 0)
+      return;
+
+    this.timer = setTimeout(() => {
+      this.reject(new Error('Worker timed out.'));
+    }, timeout);
+  }
+
+  /**
+   * Destroy the job with an error.
+   */
+
+  destroy() {
+    this.reject(new Error('Job was destroyed.'));
+  }
+
+  /**
+   * Cleanup job state.
+   * @returns {Job}
+   */
+
+  cleanup() {
+    const job = this.job;
+
+    assert(job, 'Already finished.');
+
+    this.job = null;
+
+    if (this.timer != null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+
+    assert(this.worker.pending.has(this.id));
+    this.worker.pending.delete(this.id);
+
+    return job;
+  }
+
+  /**
+   * Complete job with result.
+   * @param {Object} result
+   */
+
+  resolve(result) {
+    const job = this.cleanup();
+    job.resolve(result);
+  }
+
+  /**
+   * Complete job with error.
+   * @param {Error} err
+   */
+
+  reject(err) {
+    const job = this.cleanup();
+    job.reject(err);
+  }
+}
+
+/*
+ * Helpers
+ */
+
+function getCores() {
+  return Math.max(2, os.cpus().length);
+}
+
+/*
+ * Expose
+ */
+
+module.exports = WorkerPool;


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/109

The reason why Bob hasn't been able to spawn worker processes is because the hsd `WorkerProcess` module expects nodejs itself to be the executable that launched hsd:

[`hsd/lib/workers/child.js`:](https://github.com/handshake-org/hsd/blob/2d5ab277374ef751565caeaac84166c713ef9f4f/lib/workers/child.js#L57-L61)
```js
    const bin = process.argv[0];
    const filename = path.resolve(__dirname, file);
    const options = { stdio: 'pipe', env: process.env };


    this.child = cp.spawn(bin, [filename], options);
```

In Bob, `process.argv[0]` is raunchy:
```
/Users/matthewzipkin/Desktop/work/bob-wallet/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Helper\\(Renderer).app/Contents/MacOS/Electron Helper (Renderer) 
```
Luckily, the nodejs `child_process` module has the method `fork()` [which explicitly spawns a new nodejs process and executes the passed-in module.](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)

It's quite possible that this could be changed in hsd itself (will open an issue and check with the developers there) but for now we can hack in our own `WorkerPool` module using `fork()` instead of `spawn()`, and reconfigure our hsd node to use it instead.

The hack-in is a little awkward due to hsd's boot sequence, and where in the sequence the `WorkerPool` is actually instantiated and bound to the main process. However we are successful in spawning them: worker processes can be discovered in `htop` with the process name `hsd-worker`.


The modifications to the `WorkerPool` module can be checked by diffing against the installed hsd module:
```
$ diff app/workers/ node_modules/hsd/lib/workers/ -y --suppress-common-lines
Only in node_modules/hsd/lib/workers/: child-browser.js

diff -y --suppress-common-lines app/workers/child.js node_modules/hsd/lib/workers/child.js
							      >	    const bin = process.argv[0];
    this.child = cp.fork(filename, options);		      |	    this.child = cp.spawn(bin, [filename], options);

diff -y --suppress-common-lines app/workers/jobs.js node_modules/hsd/lib/workers/jobs.js
const _mine = require('hsd/lib/mining/mine');		      |	const _mine = require('../mining/mine');

diff -y --suppress-common-lines app/workers/master.js node_modules/hsd/lib/workers/master.js
const Network = require('hsd/lib/protocol/network');	      |	const Network = require('../protocol/network');
const ownership = require('hsd/lib/covenants/ownership');     |	const ownership = require('../covenants/ownership');

diff -y --suppress-common-lines app/workers/packets.js node_modules/hsd/lib/workers/packets.js
const Witness = require('hsd/lib/script/witness');	      |	const Witness = require('../script/witness');
const Output = require('hsd/lib/primitives/output');	      |	const Output = require('../primitives/output');
const MTX = require('hsd/lib/primitives/mtx');		      |	const MTX = require('../primitives/mtx');
const TX = require('hsd/lib/primitives/tx');		      |	const TX = require('../primitives/tx');
const KeyRing = require('hsd/lib/primitives/keyring');	      |	const KeyRing = require('../primitives/keyring');
const CoinView = require('hsd/lib/coins/coinview');	      |	const CoinView = require('../coins/coinview');
const ScriptError = require('hsd/lib/script/scripterror');    |	const ScriptError = require('../script/scripterror');
Only in node_modules/hsd/lib/workers/: parent-browser.js

diff -y --suppress-common-lines app/workers/workerpool.js node_modules/hsd/lib/workers/workerpool.js
const Network = require('hsd/lib/protocol/network');	      |	const Network = require('../protocol/network');
const ownership = require('hsd/lib/covenants/ownership');     |	const ownership = require('../covenants/ownership');
```

## Benchmark

Note these tests already include the switch to the native bcrypto backend (#122).
They were executed on my laptop with usual activity. Network bandwidth and peer connectivity may have affected each trial differently.

### This branch, trial 1

Start: `[I:2020-04-09T20:54:36Z] (chain) Chain is loading.`
Sync: `[I:2020-04-09T21:11:02Z] (chain) Block 00000000000001a86811a6f520bf67cefa03207dc84fd315f58153b28694ec51 (10000) added to chain (size=1913 txs=6 time=84.603585).`

Time: ~16.5 minutes

### Current master branch

Start: `[I:2020-04-09T21:14:11Z] (chain) Chain is loading.`
Sync: `[I:2020-04-09T21:23:14Z] (chain) Block 00000000000001a86811a6f520bf67cefa03207dc84fd315f58153b28694ec51 (10000) added to chain (size=1913 txs=6 time=9.543287).`

Time: ~9 minutes

### This branch, trial 2

Start: `[I:2020-04-09T21:24:52Z] (chain) Chain is loading.`
Sync: `[I:2020-04-09T21:35:51Z] (chain) Block 00000000000001a86811a6f520bf67cefa03207dc84fd315f58153b28694ec51 (10000) added to chain (size=1913 txs=6 time=15.1144).`

Time: ~11 minutes
