### PR TITLE
Determine `isWatching` directly from `props.watchList` instead of state

### DIFF
--- a/app/pages/Auction/BidActionPanel/index.js
+++ b/app/pages/Auction/BidActionPanel/index.js
@@ -33,15 +33,8 @@ class BidActionPanel extends Component {
 
   state = {
     isLoading: false,
-    isWatching: false,
     event: {},
   };
-
-  async componentWillMount() {
-    await this.props.getWatching(this.props.network);
-    const isWatching = this.props.watchList.includes(this.props.match.params.name);
-    this.setState({isWatching});
-  }
 
   isOwned = () => {
     const {domain} = this.props;
@@ -51,7 +44,7 @@ class BidActionPanel extends Component {
   render() {
     const {match, network} = this.props;
     const {params: {name}} = match;
-    const {isWatching} = this.state;
+    const isWatching = this.props.watchList.includes(this.props.match.params.name);
 
     return (
       <React.Fragment>
@@ -59,7 +52,7 @@ class BidActionPanel extends Component {
         <div className="domains__watch">
           <div
             className={c('domains__watch__heart-icon', {
-              'domains__watch__heart-icon--active': this.state.isWatching,
+              'domains__watch__heart-icon--active': isWatching,
             })}
             onClick={() => {
               if (isWatching) {
@@ -73,7 +66,6 @@ class BidActionPanel extends Component {
                   source: 'Bid Action Panel',
                 });
               }
-              this.setState({isWatching: !isWatching});
             }} />
           <div className="domains__watch__text">
             {isWatching ? 'Added to Watchlist' : 'Add to Watchlist'}

--- a/app/pages/Auction/BidActionPanel/index.js
+++ b/app/pages/Auction/BidActionPanel/index.js
@@ -16,11 +16,6 @@ import { clientStub as aClientStub } from '../../../background/analytics/client'
 
 const analytics = aClientStub(() => require('electron').ipcRenderer);
 
-@connect(
-  (state) => ({
-    network: state.node.network,
-  }),
-)
 class BidActionPanel extends Component {
   static propTypes = {
     domain: PropTypes.object.isRequired,


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/83

The issue here was funny stuff around when and if `componentWillMount()` fires if you go _back_ to a page you had already seen. Since the watchlist itself is updated as a prop we don't need extra function calls on state data to determine if the name is in the list. In this case, a good old fashioned local variable does the job nicely!