### PR TITLE
Reduce API calls from certain elements by keeping global state up-to-date and caching redundant data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed total amount received by a transaction with multiple outputs to the wallet
+- Fixed sluggish UI from mass of redundant rpc calls on "Your Bids" view
 
 ### Added
 - Added warning for missing bid values and functionality to repair missing bids

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -322,7 +322,7 @@ class WalletService {
   };
 
   async _executeRPC(method, args) {
-    this._selectWallet();
+    await this._selectWallet();
     return this.client.execute(method, args);
   }
 }

--- a/app/components/Sidebar/index.js
+++ b/app/components/Sidebar/index.js
@@ -10,7 +10,8 @@ import { Logo } from '../Logo';
 @connect(
   state => ({
     height: state.node.chain.height,
-    tip: state.node.chain.tip
+    tip: state.node.chain.tip,
+    newBlockStatus: state.node.newBlockStatus,
   }),
   dispatch => ({})
 )
@@ -23,7 +24,8 @@ class Sidebar extends Component {
       pathname: PropTypes.string.isRequired
     }).isRequired,
     height: PropTypes.number.isRequired,
-    tip: PropTypes.string.isRequired
+    tip: PropTypes.string.isRequired,
+    newBlockStatus: PropTypes.string.isRequired,
   };
 
   render() {
@@ -118,6 +120,9 @@ class Sidebar extends Component {
   renderFooter() {
     return (
       <div className="sidebar__footer">
+        <div className="sidebar__footer__row">
+          <div className="sidebar__footer__title">{this.props.newBlockStatus}</div>
+        </div>
         <div className="sidebar__footer__row">
           <div className="sidebar__footer__title">Current Height</div>
           <div className="sidebar__footer__text">

--- a/app/components/Sidebar/sidebar.scss
+++ b/app/components/Sidebar/sidebar.scss
@@ -73,7 +73,8 @@
 
   &__footer {
     @extend %col-nowrap;
-    padding: 1rem 0;
+    bottom: 1rem;
+    position: relative;
 
     &__row {
       @extend %col-nowrap;

--- a/app/components/Transactions/index.js
+++ b/app/components/Transactions/index.js
@@ -38,7 +38,7 @@ const ITEM_PER_DROPDOWN = [
 )
 export default class Transactions extends Component {
   static propTypes = {
-    transactions: PropTypes.array.isRequired
+    transactions: PropTypes.instanceOf(Map).isRequired
   };
 
   async componentDidMount() {
@@ -46,7 +46,7 @@ export default class Transactions extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.transactions.length !== nextProps.transactions.length) {
+    if (this.props.transactions.size !== nextProps.transactions.size) {
       this.fuse = null;
     }
   }
@@ -62,7 +62,7 @@ export default class Transactions extends Component {
 
   getTransactions() {
     const { sortBy, query } = this.state;
-    let transactions = this.props.transactions.slice();
+    let transactions = Array.from(this.props.transactions.values());
 
     if (!this.fuse) {
       this.fuse = new Fuse(transactions, {

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -54,7 +54,7 @@ export function createBackgroundMonitor() {
       });
     }
 
-    if (state.node.chain.height !== infoRes.chain.height)
+    if (state.node.chain.tip !== infoRes.chain.tip)
       await store.dispatch(onNewBlock());
 
     const newPendingTxns = await walletClient.getPendingTransactions();

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -116,6 +116,14 @@ function difference(setA, setB) {
 
 export const onNewBlock = () => async (dispatch, getState) => {
   let state = getState();
+  const isInitialized = await getInitializationState(state.node.network);
+  if (!isInitialized) {
+    return;
+  }
+
+  if (!state.wallet.initialized || !state.node.isRunning) {
+    return;
+  }
 
   dispatch({type: NEW_BLOCK_STATUS, payload: 'Updating fees...'});
   const newFees = await nodeClient.getFees();

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -44,15 +44,20 @@ export function createBackgroundMonitor() {
       chain: infoRes.chain,
       network: infoRes.network,
     };
+    store.dispatch({
+      type: SET_NODE_INFO,
+      payload: {
+        info: newInfo,
+      },
+    });
 
     const newFees = await nodeClient.getFees();
     if (!isEqual(info, newInfo) || !isEqual(fees, newFees)) {
       info = newInfo;
       fees = newFees;
       store.dispatch({
-        type: SET_NODE_INFO,
+        type: SET_FEE_INFO,
         payload: {
-          info: newInfo,
           fees: newFees,
         },
       });

--- a/app/ducks/node.js
+++ b/app/ducks/node.js
@@ -2,7 +2,15 @@ import { clientStub } from '../background/node/client';
 import { getNetwork, setNetwork } from '../db/system';
 import { fetchWallet } from './walletActions';
 import * as logger from '../utils/logClient';
-import { END_NETWORK_CHANGE, SET_NODE_INFO, START, START_ERROR, START_NETWORK_CHANGE, STOP } from './nodeReducer';
+import {
+  END_NETWORK_CHANGE,
+  SET_NODE_INFO,
+  SET_FEE_INFO,
+  START,
+  START_ERROR,
+  START_NETWORK_CHANGE,
+  STOP,
+} from './nodeReducer';
 import { VALID_NETWORKS } from '../constants/networks';
 
 const nodeClient = clientStub(() => require('electron').ipcRenderer);
@@ -47,6 +55,11 @@ const setNodeInfo = () => async (dispatch) => {
       type: SET_NODE_INFO,
       payload: {
         info,
+      },
+    });
+    dispatch({
+      type: SET_FEE_INFO,
+      payload: {
         fees,
       },
     });

--- a/app/ducks/nodeReducer.js
+++ b/app/ducks/nodeReducer.js
@@ -1,6 +1,7 @@
 export const START = 'node/START';
 export const START_ERROR = 'node/START_ERROR';
 export const SET_NODE_INFO = 'node/SET_NODE_INFO';
+export const SET_FEE_INFO = 'node/SET_FEE_INFO';
 export const STOP = 'node/STOP';
 export const START_NETWORK_CHANGE = 'node/START_NETWORK_CHANGE';
 export const END_NETWORK_CHANGE = 'node/END_NETWORK_CHANGE';
@@ -36,6 +37,10 @@ export default function nodeReducer(state = getInitialState(), action = {}) {
       return {
         ...state,
         chain: action.payload.info.chain,
+      };
+    case SET_FEE_INFO:
+      return {
+        ...state,
         fees: action.payload.fees,
       };
     case START_NETWORK_CHANGE:

--- a/app/ducks/nodeReducer.js
+++ b/app/ducks/nodeReducer.js
@@ -5,6 +5,7 @@ export const SET_FEE_INFO = 'node/SET_FEE_INFO';
 export const STOP = 'node/STOP';
 export const START_NETWORK_CHANGE = 'node/START_NETWORK_CHANGE';
 export const END_NETWORK_CHANGE = 'node/END_NETWORK_CHANGE';
+export const NEW_BLOCK_STATUS = 'node/NEW_BLOCK_STATUS';
 
 export function getInitialState() {
   return {
@@ -21,7 +22,8 @@ export function getInitialState() {
     chain: {
       height: 0,
       tip: '',
-    }
+    },
+    newBlockStatus: ''
   };
 }
 
@@ -48,6 +50,11 @@ export default function nodeReducer(state = getInitialState(), action = {}) {
       return {
         ...state,
         isChangingNetworks: action.type === START_NETWORK_CHANGE
+      };
+    case NEW_BLOCK_STATUS:
+      return {
+        ...state,
+        newBlockStatus: action.payload,
       };
     default:
       return state;

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -17,6 +17,7 @@ import {
   STOP_SYNC_WALLET,
   SYNC_WALLET_PROGRESS,
 } from './walletReducer';
+import {NEW_BLOCK_STATUS} from './nodeReducer';
 
 let idleInterval;
 
@@ -157,11 +158,24 @@ export const waitForWalletSync = () => async (dispatch, getState) => {
 };
 
 export const fetchTransactions = () => async (dispatch, getState) => {
-  const net = getState().node.network;
+  const state = getState();
+  const net = state.node.network;
+  const currentTXs = state.wallet.transactions;
   const txs = await walletClient.getTransactionHistory();
   let payload = new Map();
 
-  for (const tx of txs) {
+  for (let i = 0; i < txs.length; i++) {
+    const tx = txs[i];
+    const existing = currentTXs.get(tx.hash);
+    if (existing) {
+      const isPending = tx.block === null; 
+      existing.date = isPending ? Date.now() : Date.parse(tx.date);
+      existing.pending = isPending;
+
+      payload.set(existing.id, existing);
+      continue;
+    }
+    dispatch({type: NEW_BLOCK_STATUS, payload: `Processing TX: ${i}/${txs.length}`});
     const ios = await parseInputsOutputs(net, tx);
     const isPending = tx.block === null;
     const txData = {
@@ -173,6 +187,7 @@ export const fetchTransactions = () => async (dispatch, getState) => {
 
     payload.set(tx.hash, txData);
   }
+  dispatch({type: NEW_BLOCK_STATUS, payload: ''});
 
   // Sort all TXs by date without losing the hash->tx mapping
   payload = new Map([...payload.entries()].sort((a, b) => b[1].date - a[1].date));

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -159,21 +159,15 @@ export const waitForWalletSync = () => async (dispatch, getState) => {
 export const fetchTransactions = () => async (dispatch, getState) => {
   const net = getState().node.network;
   const txs = await walletClient.getTransactionHistory();
-  let aggregate = new BigNumber(0);
   let payload = [];
 
   for (const tx of txs) {
     const ios = await parseInputsOutputs(net, tx);
-    aggregate =
-      ios.type !== 'RECEIVE'
-        ? aggregate.minus(ios.value)
-        : aggregate.plus(ios.value);
     const isPending = tx.block === null;
     const txData = {
       id: tx.hash,
       date: isPending ? Date.now() : Date.parse(tx.date),
       pending: isPending,
-      balance: aggregate.toString(),
       ...ios,
     };
 

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -159,7 +159,7 @@ export const waitForWalletSync = () => async (dispatch, getState) => {
 export const fetchTransactions = () => async (dispatch, getState) => {
   const net = getState().node.network;
   const txs = await walletClient.getTransactionHistory();
-  let payload = [];
+  let payload = new Map();
 
   for (const tx of txs) {
     const ios = await parseInputsOutputs(net, tx);
@@ -171,15 +171,11 @@ export const fetchTransactions = () => async (dispatch, getState) => {
       ...ios,
     };
 
-    if (isPending) {
-      payload.unshift(txData);
-      continue;
-    }
-
-    payload.push(txData);
+    payload.set(tx.hash, txData);
   }
 
-  payload = payload.sort((a, b) => b.date - a.date);
+  // Sort all TXs by date without losing the hash->tx mapping
+  payload = new Map([...payload.entries()].sort((a, b) => b[1].date - a[1].date));
 
   dispatch({
     type: SET_TRANSACTIONS,

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -25,7 +25,7 @@ export function getInitialState() {
       confirmed: '0',
       unconfirmed: '0'
     },
-    transactions: [],
+    transactions: new Map(),
     idle: 0,
     walletSync: false,
     walletSyncProgress: 0,
@@ -56,7 +56,7 @@ export default function walletReducer(state = getInitialState(), {type, payload}
           ...state.balance
         },
         isLocked: true,
-        transactions: []
+        transactions: new Map()
       };
     case UNLOCK_WALLET:
       return {

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -25,6 +25,7 @@ import * as walletActions from '../../ducks/walletActions';
 import './app.scss';
 import AccountLogin from '../AcountLogin';
 import * as node from '../../ducks/node';
+import { onNewBlock } from '../../ducks/backgroundMonitor';
 import Notification from '../../components/Notification';
 import SplashScreen from "../../components/SplashScreen";
 import WalletSync from "../../components/WalletSync";
@@ -37,8 +38,8 @@ class App extends Component {
     error: PropTypes.string.isRequired,
     isLocked: PropTypes.bool.isRequired,
     initialized: PropTypes.bool.isRequired,
-    fetchWallet: PropTypes.func.isRequired,
     startNode: PropTypes.func.isRequired,
+    onNewBlock: PropTypes.func.isRequired,
     watchActivity: PropTypes.func.isRequired,
     isChangingNetworks: PropTypes.bool.isRequired,
   };
@@ -50,7 +51,7 @@ class App extends Component {
   async componentDidMount() {
     this.setState({isLoading: true});
     await this.props.startNode();
-    await this.props.fetchWallet();
+    await this.props.onNewBlock();
     this.props.watchActivity();
     setTimeout(() => this.setState({isLoading: false}), 1000)
   }
@@ -229,9 +230,9 @@ export default withRouter(
       initialized: state.wallet.initialized
     }),
     dispatch => ({
-      fetchWallet: () => dispatch(walletActions.fetchWallet()),
       watchActivity: () => dispatch(walletActions.watchActivity()),
       startNode: () => dispatch(node.start()),
+      onNewBlock: () => dispatch(onNewBlock()),
     })
   )(App)
 );

--- a/app/pages/Settings/ZapTXsModal.js
+++ b/app/pages/Settings/ZapTXsModal.js
@@ -21,7 +21,7 @@ import {showError, showSuccess } from '../../ducks/notifications';
 )
 class ZapTXsModal extends Component {
   static propTypes = {
-    transactions: PropTypes.array.isRequired,
+    transactions: PropTypes.instanceOf(Map).isRequired,
     showError: PropTypes.func.isRequired,
     showSuccess: PropTypes.func.isRequired,
   };
@@ -51,10 +51,10 @@ class ZapTXsModal extends Component {
     if (this.props.transactions) {
       const txs = [];
 
-      for (const tx of this.props.transactions) {
+      this.props.transactions.forEach( tx => {
         if (tx.pending)
           txs.push(tx);
-      }
+      });
 
       if (txs.length === 0) {
         txList.push(

--- a/app/pages/YourBids/BidAction.js
+++ b/app/pages/YourBids/BidAction.js
@@ -10,13 +10,8 @@ class BidAction extends Component {
   static propTypes = {
     address: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-    getNameInfo: PropTypes.func.isRequired,
     domain: PropTypes.object,
   };
-
-  componentWillMount() {
-    this.props.getNameInfo();
-  }
 
   isReveal = () => isReveal(this.props.domain);
 
@@ -133,7 +128,6 @@ export default withRouter(
       };
     },
     (dispatch, ownProps) => ({
-      getNameInfo: () => dispatch(nameActions.getNameInfo(ownProps.name)),
       sendRedeem: () => dispatch(nameActions.sendRedeem(ownProps.name)),
       showError: (message) => dispatch(showError(message)),
       showSuccess: (message) => dispatch(showSuccess(message)),

--- a/app/pages/YourBids/BidStatus.js
+++ b/app/pages/YourBids/BidStatus.js
@@ -3,7 +3,6 @@ import cn from 'classnames';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import * as nameActions from '../../ducks/names';
 import {
   isReveal,
   isClosed,
@@ -18,12 +17,7 @@ class BidStatus extends Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
     address: PropTypes.string.isRequired,
-    getNameInfo: PropTypes.func.isRequired,
   };
-
-  componentWillMount() {
-    this.props.getNameInfo();
-  }
 
   isSold = () => isClosed(this.props.domain);
   isReveal = () => isReveal(this.props.domain);
@@ -157,9 +151,6 @@ export default withRouter(
         domain: name,
         address: state.wallet.address,
       };
-    },
-    (dispatch, ownProps) => ({
-      getNameInfo: () => dispatch(nameActions.getNameInfo(ownProps.name)),
-    }),
+    }
   )(BidStatus)
 );

--- a/app/pages/YourBids/BidTimeLeft.js
+++ b/app/pages/YourBids/BidTimeLeft.js
@@ -2,20 +2,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import * as nameActions from '../../ducks/names';
 import { isReveal, isBidding, isOpening } from '../../utils/nameHelpers';
 import { hoursToNow } from '../../utils/timeConverter';
 
 class BidTimeLeft extends Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
-    getNameInfo: PropTypes.func.isRequired,
     domain: PropTypes.object,
   };
-
-  componentWillMount() {
-    this.props.getNameInfo();
-  }
 
   isReveal = () => isReveal(this.props.domain);
 
@@ -57,9 +51,6 @@ export default withRouter(
       return {
         domain: name,
       };
-    },
-    (dispatch, ownProps) => ({
-      getNameInfo: () => dispatch(nameActions.getNameInfo(ownProps.name)),
-    }),
+    }
   )(BidTimeLeft)
 );

--- a/app/pages/YourBids/index.js
+++ b/app/pages/YourBids/index.js
@@ -7,7 +7,6 @@ import BidTimeLeft from './BidTimeLeft';
 import BidAction from './BidAction';
 import { HeaderItem, HeaderRow, Table, TableItem, TableRow } from '../../components/Table';
 import BidSearchInput from '../../components/BidSearchInput';
-import * as bidsActions from '../../ducks/bids';
 import { displayBalance } from '../../utils/balances';
 import Fuse from '../../vendor/fuse';
 import './your-bids.scss';
@@ -82,9 +81,6 @@ export default withRouter(
   connect(
     state => ({
       yourBids: state.bids.yourBids,
-    }),
-    dispatch => ({
-      getYourBids: dispatch(bidsActions.getYourBids()),
     })
   )(YourBids)
 );


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/100

This PR reduces API calls in certain views to improve UI performance. The "Your Bids" view in particular has a table with three elements per bid: each of these elements was individually calling `getNameInfo()` on the same name! In addition, the use of `componentWillMount()` in certain elements to update state is insufficient since a new block event (and state update) will not trigger this method. The elements themselves should just rely on the global state being updated already.

Since bids and namestates only change when new blocks connect to the chain, we only really need to gather this data once per block. The data is already stored in the global state, so all we have to do is change _when_ it is updated.

This patch adds a new function `onNewBlock()` to `backgroundMonitor` which is executed any time a `doPoll()` encounters a new block from hsd. This function gets current fee rates, gets all bids, and then iterates through all the bids getting updated namestates. This means that on every new block, UI may be a bit sluggish for a minute. A new progress indicator is added in the sidebar footer.

Tested by running a bash script that opened 300 names and then bid once or twice on each name.

Future work:
- Add pagination to hsd wallet (see https://github.com/bcoin-org/bcoin/pull/605)
- Add functionality either in Bob or hsd to filter out expired auctions or bids that "don't matter anymore" for one reason or another.
- Switch the hsd<->Bob link from 10-second polling to **websocket events**. If possible, this will keep Bob up to date with essentially zero lag.
- Explore `getNameInfo` for ways to reduce 2 API calls (`node.getNameInfo` + `wallet.getAuctionInfo`) to one, or cache some data if possible.

### Demonstration

UI elements seem more responsive than before even when a new block is being processed. Once the new block processing is done, everything is perfectly snappy since no new API calls are made when loading/changing views.

Note the new "New Block Status" message just above the current height in the sidebar footer.

![LoadBidsOnNewBlock](https://user-images.githubusercontent.com/2084648/79275727-be2abf00-7e74-11ea-98db-44ee47a112da.gif)
