### PR TITLE
Separate idle modal and Bob "lock" from underlying hsd wallet lock. Request user passphrase when needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 with "spendable" balance which is total unconfirmed minus total locked coins
 - Covenants in portfolio view now display their value as it affects spendable balance
 - Improvements to maxSend based on spendable balance and cleaner fee estimation
+- Bob will ask user for passphrase whenever private key is needed (e.g. send TX)
+- Bob will no longer "logout" when underlying hsd wallet is locked, however
+Bob will still lock the hsd wallet on logout or idle timeout
 
 ## [0.2.8] - 2020-03-17
 ### Fixed

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -151,7 +151,8 @@ class WalletService {
         value: Number(toBaseUnits(amount)),
         address: to,
       }],
-      subtractFee
+      subtractFee,
+      sign: false,
     });
     return {
       feeRate,

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -222,7 +222,7 @@ class WalletService {
 
   unlock = (passphrase) => this._ledgerProxy(
     () => null,
-    () => this.client.unlock(WALLET_ID, passphrase, 60 * 60 * 24 * 365),
+    () => this.client.unlock(WALLET_ID, passphrase),
   );
 
   isLocked = () => this._ledgerProxy(

--- a/app/components/Modal/MiniModal.js
+++ b/app/components/Modal/MiniModal.js
@@ -7,7 +7,7 @@ import './mini-modal.scss';
 
 export class MiniModal extends Component {
   static propTypes = {
-    closeRoute: PropTypes.string.isRequired,
+    closeRoute: PropTypes.string,
     children: PropTypes.node.isRequired,
     title: PropTypes.string.isRequired,
     centered: PropTypes.bool,
@@ -15,7 +15,9 @@ export class MiniModal extends Component {
   };
 
   onClose = () => {
-    this.props.history.push(this.props.closeRoute)
+    this.props.closeRoute
+    ? this.props.history.push(this.props.closeRoute)
+    : this.props.history.goBack();
   };
 
   render() {

--- a/app/components/Modal/MiniModal.js
+++ b/app/components/Modal/MiniModal.js
@@ -8,6 +8,7 @@ import './mini-modal.scss';
 export class MiniModal extends Component {
   static propTypes = {
     closeRoute: PropTypes.string,
+    onClose: PropTypes.func,
     children: PropTypes.node.isRequired,
     title: PropTypes.string.isRequired,
     centered: PropTypes.bool,
@@ -15,6 +16,9 @@ export class MiniModal extends Component {
   };
 
   onClose = () => {
+    if (this.props.onClose)
+      return this.props.onClose();
+
     this.props.closeRoute
     ? this.props.history.push(this.props.closeRoute)
     : this.props.history.goBack();

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -2,7 +2,7 @@ import walletClient from '../utils/walletClient';
 import nodeClient from '../utils/nodeClient';
 import * as logger from '../utils/logClient';
 import { store } from '../store/configureStore';
-import { LOCK_WALLET, SET_PENDING_TRANSACTIONS } from './walletReducer';
+import { SET_PENDING_TRANSACTIONS } from './walletReducer';
 import { getInitializationState } from '../db/system';
 import isEqual from 'lodash.isequal';
 import { SET_NODE_INFO, SET_FEE_INFO, NEW_BLOCK_STATUS } from './nodeReducer';
@@ -11,7 +11,6 @@ import { getYourBids } from './bids';
 import { fetchTransactions, fetchWallet } from './walletActions';
 
 export function createBackgroundMonitor() {
-  let isLocked;
   let timeout;
   let info;
   let prevNamesWithPendingUpdates = new Set();
@@ -24,18 +23,6 @@ export function createBackgroundMonitor() {
     }
 
     if (!state.wallet.initialized || !state.node.isRunning) {
-      return;
-    }
-
-    const newIsLocked = await walletClient.isLocked();
-    if (newIsLocked) {
-      if (newIsLocked !== isLocked) {
-        isLocked = newIsLocked;
-        store.dispatch({
-          type: LOCK_WALLET,
-        });
-      }
-
       return;
     }
 

--- a/app/ducks/myDomains.js
+++ b/app/ducks/myDomains.js
@@ -1,5 +1,4 @@
 import walletClient from '../utils/walletClient';
-import { SET_PENDING_TRANSACTIONS } from './walletActions';
 
 const FETCH_MY_NAMES_START = 'app/myDomains/fetchMyNamesStart';
 const FETCH_MY_NAMES_STOP = 'app/myDomains/fetchMyNamesStop';

--- a/app/ducks/names.js
+++ b/app/ducks/names.js
@@ -6,7 +6,6 @@ import {
   stopWalletSync,
   waitForWalletSync,
   fetchPendingTransactions,
-  SET_PENDING_TRANSACTIONS
 } from './walletActions';
 import { SET_NAME } from './namesReducer';
 

--- a/app/ducks/names.js
+++ b/app/ducks/names.js
@@ -6,6 +6,7 @@ import {
   stopWalletSync,
   waitForWalletSync,
   fetchPendingTransactions,
+  getPassphrase,
 } from './walletActions';
 import { SET_NAME } from './namesReducer';
 
@@ -138,6 +139,10 @@ async function inflateReveals(nClient, walletClient, bids) {
 }
 
 export const sendOpen = name => async (dispatch) => {
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
+
   await walletClient.sendOpen(name);
   await namesDb.storeName(name);
   await dispatch(fetchPendingTransactions());
@@ -147,6 +152,9 @@ export const sendBid = (name, amount, lockup, height) => async (dispatch) => {
   if (!name) {
     return;
   }
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
 
   if (height) {
     try {
@@ -164,34 +172,46 @@ export const sendBid = (name, amount, lockup, height) => async (dispatch) => {
   await namesDb.storeName(name);
 };
 
-export const sendReveal = (name) => async () => {
+export const sendReveal = (name) => async (dispatch) => {
   if (!name) {
     return;
   }
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
 
   await namesDb.storeName(name);
   await walletClient.sendReveal(name);
 };
 
-export const sendRedeem = (name) => async () => {
+export const sendRedeem = (name) => async (dispatch) => {
   if (!name) {
     return;
   }
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
 
   await namesDb.storeName(name);
   await walletClient.sendRedeem(name);
 };
 
-export const sendRenewal = (name) => async () => {
+export const sendRenewal = (name) => async (dispatch) => {
   if (!name) {
     return;
   }
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
 
   await namesDb.storeName(name);
   await walletClient.sendRenewal(name);
 };
 
 export const sendUpdate = (name, json) => async (dispatch) => {
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
   await namesDb.storeName(name);
   await walletClient.sendUpdate(name, json);
   await dispatch(fetchPendingTransactions());

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -26,7 +26,6 @@ export const setWallet = opts => {
     initialized = false,
     address = '',
     type = NONE,
-    isLocked = true,
     balance = {},
   } = opts;
 
@@ -36,7 +35,6 @@ export const setWallet = opts => {
       initialized,
       address,
       type,
-      isLocked,
       balance,
     },
   };
@@ -61,7 +59,6 @@ export const fetchWallet = () => async (dispatch, getState) => {
       initialized: false,
       address: '',
       type: NONE,
-      isLocked: true,
       balance: {
         ...getInitialState().balance,
       },
@@ -69,12 +66,10 @@ export const fetchWallet = () => async (dispatch, getState) => {
   }
 
   const accountInfo = await walletClient.getAccountInfo();
-  const isLocked = await walletClient.isLocked();
   dispatch(setWallet({
     initialized: isInitialized,
     address: accountInfo && accountInfo.receiveAddress,
     type: NONE,
-    isLocked,
     balance: (accountInfo && accountInfo.balance) || {
       ...getInitialState().balance,
     },
@@ -87,7 +82,9 @@ export const revealSeed = (passphrase) => async () => {
 
 export const unlockWallet = passphrase => async (dispatch) => {
   await walletClient.unlock(passphrase);
-  await dispatch(fetchWallet());
+  dispatch({
+    type: UNLOCK_WALLET,
+  });
 };
 
 export const lockWallet = () => async (dispatch) => {

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -16,6 +16,7 @@ import {
   START_SYNC_WALLET,
   STOP_SYNC_WALLET,
   SYNC_WALLET_PROGRESS,
+  GET_PASSPHRASE,
 } from './walletReducer';
 import {NEW_BLOCK_STATUS} from './nodeReducer';
 
@@ -102,6 +103,9 @@ export const removeWallet = () => async (dispatch, getState) => {
 };
 
 export const send = (to, amount, fee) => async (dispatch) => {
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
   const res = await walletClient.send(to, amount, fee);
   await dispatch(fetchWallet());
   return res;
@@ -213,6 +217,16 @@ const incrementIdle = () => ({
 
 export const resetIdle = () => ({
   type: RESET_IDLE,
+});
+
+export const getPassphrase = (resolve, reject) => ({
+  type: GET_PASSPHRASE,
+  payload: {get: true, resolve, reject},
+});
+
+export const closeGetPassphrase = () => ({
+  type: GET_PASSPHRASE,
+  payload: {get: false},
 });
 
 export const watchActivity = () => dispatch => {

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -41,7 +41,6 @@ export default function walletReducer(state = getInitialState(), {type, payload}
         ...state,
         address: payload.address,
         type: payload.type,
-        isLocked: payload.isLocked,
         balance: {
           ...state.balance,
           confirmed: payload.balance.confirmed,
@@ -55,11 +54,7 @@ export default function walletReducer(state = getInitialState(), {type, payload}
     case LOCK_WALLET:
       return {
         ...state,
-        balance: {
-          ...state.balance
-        },
-        isLocked: true,
-        transactions: new Map()
+        isLocked: true
       };
     case UNLOCK_WALLET:
       return {

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -13,6 +13,7 @@ export const SET_PENDING_TRANSACTIONS = 'app/wallet/setPendingTransactions';
 export const START_SYNC_WALLET = 'app/wallet/startSyncWallet';
 export const STOP_SYNC_WALLET = 'app/wallet/stopSyncWallet';
 export const SYNC_WALLET_PROGRESS = 'app/wallet/syncWalletProgress';
+export const GET_PASSPHRASE = 'app/wallet/getPassphrase';
 
 export function getInitialState() {
   return {
@@ -31,6 +32,7 @@ export function getInitialState() {
     idle: 0,
     walletSync: false,
     walletSyncProgress: 0,
+    getPassphrase: {get: false},
   };
 }
 
@@ -90,6 +92,11 @@ export default function walletReducer(state = getInitialState(), {type, payload}
       return {
         ...state,
         walletSyncProgress: payload,
+      };
+    case GET_PASSPHRASE:
+      return {
+        ...state,
+        getPassphrase: payload,
       };
     default:
       return state;

--- a/app/pages/AcountLogin/PassphraseModal.js
+++ b/app/pages/AcountLogin/PassphraseModal.js
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import c from 'classnames';
+import * as walletActions from '../../ducks/walletActions';
+import './login.scss';
+import Submittable from '../../components/Submittable';
+import { Link } from 'react-router-dom';
+import MiniModal from '../../components/Modal/MiniModal';
+
+@connect(
+  (state) => ({
+    getPassphrase: state.wallet.getPassphrase,
+  }),
+  dispatch => ({
+    unlockWallet: passphrase => dispatch(walletActions.unlockWallet(passphrase)),
+    closeGetPassphrase: () => dispatch(walletActions.closeGetPassphrase()),
+  })
+)
+export default class PassphraseModal extends Component {
+  static propTypes = {
+    unlockWallet: PropTypes.func.isRequired,
+    closeGetPassphrase: PropTypes.func.isRequired,
+    getPassphrase: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    className: ''
+  };
+
+  state = {
+    passphrase: '',
+    showError: false
+  };
+
+  async handleLogin(passphrase) {
+    try {
+      await this.props.unlockWallet(passphrase);
+      this.setState({passphrase: ''});
+      this.props.getPassphrase.resolve();
+      this.props.closeGetPassphrase();
+    } catch (error) {
+      return this.setState({ showError: true });
+    }
+  }
+
+  onClose = () => {
+    this.setState({passphrase:'', showError: false});
+    this.props.getPassphrase.reject({message: 'No Password'});
+    this.props.closeGetPassphrase();
+  };
+
+  render() {
+    const { passphrase, showError } = this.state;
+
+    if (!this.props.getPassphrase.get)
+      return null;
+
+    return (
+      <MiniModal
+        onClose={this.onClose}
+        title="Enter Password"
+        centered
+      >
+        <Submittable onSubmit={() => this.handleLogin(passphrase)}>
+          <div>
+            <input
+              className={c('login_password_input', {
+                'login_password_input--error': showError
+              })}
+              type="password"
+              placeholder="Your password"
+              onChange={e =>
+                this.setState({ passphrase: e.target.value, showError: false })
+              }
+              value={passphrase}
+              autoFocus
+            />
+          </div>
+          <div className="login_password_error">
+            {showError && `Invalid password.`}
+          </div>
+        </Submittable>
+        <button
+          className="extension_cta_button login_cta"
+          onClick={() => this.handleLogin(passphrase)}
+        >
+          Submit
+        </button>
+      </MiniModal>
+    );
+  }
+}

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -24,6 +24,7 @@ import SearchTLD from '../SearchTLD';
 import * as walletActions from '../../ducks/walletActions';
 import './app.scss';
 import AccountLogin from '../AcountLogin';
+import PassphraseModal from '../AcountLogin/PassphraseModal';
 import * as node from '../../ducks/node';
 import { onNewBlock } from '../../ducks/backgroundMonitor';
 import Notification from '../../components/Notification';
@@ -70,6 +71,7 @@ class App extends Component {
       <div className="app">
         <WalletSync />
         <IdleModal />
+        <PassphraseModal />
         {this.renderContent()}
       </div>
     );

--- a/app/pages/Auction/BidActionPanel/OpenBid.js
+++ b/app/pages/Auction/BidActionPanel/OpenBid.js
@@ -36,7 +36,7 @@ class OpenBid extends Component {
     } catch (e) {
       console.error(e);
       logger.error(`Error received from OpenBid - sendOpen]\n\n${e.message}\n${e.stack}\n`);
-      this.props.showError('Failed to open bid. Please try again.');
+      this.props.showError(`Failed to open bid: ${e.message}`);
     }
   };
 

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -60,7 +60,7 @@ class Reveal extends Component {
     } catch (e) {
       console.error(e);
       logger.error(`Error received from Reveal - sendReveal]\n\n${e.message}\n${e.stack}\n`);
-      this.props.showError('Failed to reveal bid. Please try again.');
+      this.props.showError(`Failed to reveal bid: ${e.message}`);
     }
   };
 


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/104

### Changes

- Removes logic in `doPoll` that logs out of Bob if hsd wallet is locked
- Adds new passphrase modal that accepts callback (Promise.resolve) and can interrupt any process to unlock the hsd wallet, then return to the caller.
- Various cleanup and nitpicks to construct new modal

The new UX will be:
- Passphrase required to log in to wallet (for privacy, no change)
- Once logged in, after 5 minutes of idling, Bob logs out and locks hsd wallet (no change)
- Any time private key is needed (send, open, bid, reveal, renew, update, redeem) the modal pops up and calls `wallet.unlock()` (new)
- Any time wallet is unlocked, the default timeout (60 seconds) is applied. There is no feedback to the user when the time expires and the wallet is locked. That won't be necessary anyway because we always get the passphrase again whenever we actually need it.


### Demonstration

Demonstrating closing modal without passphrase (error is displayed to user), entering wrong passphrase, and entering correct passphrase.


![require-password](https://user-images.githubusercontent.com/2084648/79901319-a8217f00-83dd-11ea-93c9-d5cc2ff0bf2e.gif)
