### PR TITLE
Introduce "Spendable Balance" and refer all TX values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatically rescan auction if a user bids on a name that is not already in the wallet
 - Introduce "Wallet Sync" modal that blocks UI and displays wallet rescan progress
 
+### Changed
+- Switch bcrypto backend to native for remarkable performance improvements
+- Total Balance is now the "unconfirmed" balance from hsd. Unlocked balance is replaced
+with "spendable" balance which is total unconfirmed minus total locked coins
+- Covenants in portfolio view now display their value as it affects spendable balance
+- Improvements to maxSend based on spendable balance and cleaner fee estimation
+
 ## [0.2.8] - 2020-03-17
 ### Fixed
 - Fixed a crash when names transitioned from the bidding to revealing state

--- a/app/components/SendModal/index.js
+++ b/app/components/SendModal/index.js
@@ -134,6 +134,28 @@ class SendModal extends Component {
     });
   };
 
+  onClickContinue = async () => {
+    if (!this.validate()) {
+      return;
+    }
+
+    let feeInfo;
+    try {
+      feeInfo = await walletClient.estimateTxFee(this.state.to, this.state.amount, this.state.gasFee);
+    } catch (e) {
+      this.setState({
+        errorMessage: e.message,
+      });
+      return;
+    }
+
+    this.setState({
+      feeAmount: feeInfo.amount,
+      txSize: feeInfo.txSize,
+      isConfirming: true,
+    });
+  };
+
   addDecimalsToInteger(amount) {
     if (amount % 1 === 0) {
       return bn(amount).toFixed(2);
@@ -253,28 +275,6 @@ class SendModal extends Component {
       </div>
     );
   }
-
-  onClickContinue = async () => {
-    if (!this.validate()) {
-      return;
-    }
-
-    let feeInfo;
-    try {
-      feeInfo = await walletClient.estimateTxFee(this.state.to, this.state.amount, this.state.gasFee);
-    } catch (e) {
-      this.setState({
-        errorMessage: e.message,
-      });
-      return;
-    }
-
-    this.setState({
-      feeAmount: feeInfo.amount,
-      txSize: feeInfo.txSize,
-      isConfirming: true,
-    });
-  };
 
   renderConfirm() {
     const {

--- a/app/components/Topbar/index.js
+++ b/app/components/Topbar/index.js
@@ -20,8 +20,8 @@ import * as walletActions from '../../ducks/walletActions';
       isSynchronizing: isRunning && progress < 1,
       isSynchronized: isRunning && progress === 1,
       progress,
-      confirmedBalance: state.wallet.balance.confirmed,
       unconfirmedBalance: state.wallet.balance.unconfirmed,
+      spendableBalance: state.wallet.balance.spendable,
     };
   },
   dispatch => ({
@@ -42,8 +42,8 @@ class Topbar extends Component {
     isSynchronizing: PropTypes.bool.isRequired,
     isSynchronized: PropTypes.bool.isRequired,
     lockWallet: PropTypes.func.isRequired,
-    confirmedBalance: PropTypes.number,
     unconfirmedBalance: PropTypes.number,
+    spendableBalance: PropTypes.number,
   };
 
   state = {
@@ -122,7 +122,7 @@ class Topbar extends Component {
   }
 
   renderSettingIcon() {
-    const { confirmedBalance, unconfirmedBalance } = this.props;
+    const { unconfirmedBalance, spendableBalance } = this.props;
     const { isShowingSettingMenu } = this.state;
     return (
       <div
@@ -143,9 +143,9 @@ class Topbar extends Component {
                     </div>
                   </div>
                   <div className="setting-menu__balance-container__item">
-                    <div className="setting-menu__balance-container__item__label">Unlocked Balance</div>
+                    <div className="setting-menu__balance-container__item__label">Spendable Balance</div>
                     <div className="setting-menu__balance-container__item__amount">
-                      {`HNS ${displayBalance(confirmedBalance)}`}
+                      {`HNS ${displayBalance(spendableBalance)}`}
                     </div>
                   </div>
                 </div>

--- a/app/components/Transactions/Transaction/index.js
+++ b/app/components/Transactions/Transaction/index.js
@@ -49,14 +49,12 @@ class Transaction extends Component {
          && !tx.pending,
       'transaction__number--neutral':
         (tx.type === UPDATE
-        || tx.type === RENEW)
+        || tx.type === RENEW
+        || tx.type === OPEN)
         && !tx.pending,
       'transaction__number--negative':
-        (tx.type !== RECEIVE
-        && tx.type !== REVEAL
-        && tx.type !== REDEEM
-        && tx.type !== RENEW
-        && tx.type !== COINBASE)
+        (tx.type === SEND
+        || tx.type === BID)
         && !tx.pending,
     });
 
@@ -84,7 +82,7 @@ class Transaction extends Component {
       description = 'Received Funds';
       content = ellipsify(tx.meta.from, 12);
     } else if (tx.type === OPEN) {
-      description = 'Opened Bid';
+      description = 'Opened Auction';
       content = this.formatDomain(tx.meta.domain);
     } else if (tx.type === BID) {
       description = 'Placed Bid';
@@ -126,7 +124,7 @@ class Transaction extends Component {
         {' '}
         {
           tx.type === RECEIVE || tx.type === COINBASE || tx.type === REDEEM || tx.type === REVEAL ? '+'
-          : tx.type === UPDATE || tx.type === RENEW ? ''
+          : tx.type === UPDATE || tx.type === RENEW || tx.type === OPEN ? ''
           : '-'
         }
         {displayBalance(tx.value)} HNS

--- a/app/components/Transactions/Transaction/index.js
+++ b/app/components/Transactions/Transaction/index.js
@@ -41,8 +41,23 @@ class Transaction extends Component {
   numberStyling = tx =>
     classnames('transaction__number', {
       'transaction__number--pending': tx.pending,
-      'transaction__number--positive': (tx.type === RECEIVE || tx.type === COINBASE) && !tx.pending,
-      'transaction__number--negative': (tx.type !== RECEIVE && tx.type !== COINBASE) && !tx.pending,
+      'transaction__number--positive':
+        (tx.type === RECEIVE
+        || tx.type === COINBASE
+        || tx.type === REVEAL
+        || tx.type === REDEEM)
+         && !tx.pending,
+      'transaction__number--neutral':
+        (tx.type === UPDATE
+        || tx.type === RENEW)
+        && !tx.pending,
+      'transaction__number--negative':
+        (tx.type !== RECEIVE
+        && tx.type !== REVEAL
+        && tx.type !== REDEEM
+        && tx.type !== RENEW
+        && tx.type !== COINBASE)
+        && !tx.pending,
     });
 
   renderTimestamp = tx => {
@@ -92,6 +107,8 @@ class Transaction extends Component {
       description = 'Unknown Transaction';
     }
 
+    description += tx.meta.multiple ? ' (multiple)' : '';
+
     return (
       <div className="transaction__tx-description">
         <div className={this.titleStyling(tx)} onClick={this.onClickTitle}>{description}</div>
@@ -107,7 +124,11 @@ class Transaction extends Component {
       <div className={this.numberStyling(tx)}>
         {tx.pending ? <em>(pending)</em> : null}
         {' '}
-        {tx.type === RECEIVE || tx.type === COINBASE ? '+' : '-'}
+        {
+          tx.type === RECEIVE || tx.type === COINBASE || tx.type === REDEEM || tx.type === REVEAL ? '+'
+          : tx.type === UPDATE || tx.type === RENEW ? ''
+          : '-'
+        }
         {displayBalance(tx.value)} HNS
       </div>
     </div>

--- a/app/components/Transactions/index.scss
+++ b/app/components/Transactions/index.scss
@@ -112,6 +112,10 @@
         color: $manatee-gray;
       }
     }
+
+    &--neutral {
+      color: $black;
+    }
   }
 }
 

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -22,8 +22,10 @@ export function getInitialState() {
     initialized: false,
     network: '',
     balance: {
-      confirmed: '0',
-      unconfirmed: '0'
+      confirmed: 0,
+      unconfirmed: 0,
+      lockedConfirmed: 0,
+      lockedUnconfirmed: 0,
     },
     transactions: [],
     idle: 0,
@@ -42,10 +44,11 @@ export default function walletReducer(state = getInitialState(), {type, payload}
         isLocked: payload.isLocked,
         balance: {
           ...state.balance,
-          confirmed: payload.balance.confirmed || 0,
-          unconfirmed: payload.balance.unconfirmed || 0,
-          lockedUnconfirmed: payload.balance.lockedUnconfirmed || 0,
-          lockedConfirmed: payload.balance.lockedConfirmed || 0,
+          confirmed: payload.balance.confirmed,
+          unconfirmed: payload.balance.unconfirmed,
+          lockedUnconfirmed: payload.balance.lockedUnconfirmed,
+          lockedConfirmed: payload.balance.lockedConfirmed,
+          spendable: payload.balance.unconfirmed - payload.balance.lockedUnconfirmed,
         },
         initialized: payload.initialized
       };

--- a/app/pages/Account/index.js
+++ b/app/pages/Account/index.js
@@ -13,15 +13,15 @@ const analytics = aClientStub(() => require('electron').ipcRenderer);
 
 @connect(
   (state) => ({
-    confirmedBalance: state.wallet.balance.confirmed,
     unconfirmedBalance: state.wallet.balance.unconfirmed,
+    spendableBalance: state.wallet.balance.spendable,
     height: state.node.chain.height,
   }),
 )
 export default class Account extends Component {
   static propTypes = {
-    confirmedBalance: PropTypes.number.isRequired,
     unconfirmedBalance: PropTypes.number.isRequired,
+    spendableBalance: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
   };
 
@@ -30,7 +30,7 @@ export default class Account extends Component {
   }
 
   render() {
-    const {confirmedBalance, unconfirmedBalance} = this.props;
+    const {unconfirmedBalance, spendableBalance} = this.props;
 
     return (
       <div className="account">
@@ -46,14 +46,14 @@ export default class Account extends Component {
           </div>
           <div className="account__header-section">
             <div className="account__address">
-              <div>Unlocked Balance</div>
+              <div>Spendable Balance</div>
               <Tooltipable
-                tooltipContent="Unlocked balance equals your current balance that's written on the HNS blockchain. It does not reflect pending transactions.">
+                tooltipContent="Spendable balance represents all coins in the wallet (both confirmed and unconfirmed) that are not locked by auction bids or registered names.">
                 <div className="account__info-icon" />
               </Tooltipable>
             </div>
             <div className="account__balance-wrapper">
-              <div className="account__balance-wrapper__amount">{`HNS ${displayBalance(confirmedBalance)}`}</div>
+              <div className="account__balance-wrapper__amount">{`HNS ${displayBalance(spendableBalance)}`}</div>
             </div>
           </div>
         </div>

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -29,7 +29,7 @@ class BidNow extends Component {
     totalMasks: PropTypes.number.isRequired,
     ownHighestBid: PropTypes.object.isRequired,
     isPending: PropTypes.bool.isRequired,
-    confirmedBalance: PropTypes.number.isRequired,
+    spendableBalance: PropTypes.number.isRequired,
     getNameInfo: PropTypes.func.isRequired,
     waitForWalletSync: PropTypes.func.isRequired,
     startWalletSync: PropTypes.func.isRequired,
@@ -164,7 +164,7 @@ class BidNow extends Component {
       bidAmount,
     } = this.state;
 
-    const {confirmedBalance} = this.props;
+    const {spendableBalance} = this.props;
 
     return (
       <AuctionPanelFooter>
@@ -193,7 +193,7 @@ class BidNow extends Component {
         </div>
         <div className="domains__bid-now__action domains__bid-now__action--placing-bid">
           <div className="domains__bid-now__HNS-status">
-            {`${displayBalance(confirmedBalance)} HNS Unlocked Balance Available`}
+            {`${displayBalance(spendableBalance)} HNS Spendable Balance Available`}
           </div>
         </div>
       </AuctionPanelFooter>
@@ -384,7 +384,7 @@ class BidNow extends Component {
 
 export default connect(
   (state, {domain}) => ({
-    confirmedBalance: state.wallet.balance.confirmed,
+    spendableBalance: state.wallet.balance.spendable,
     ownHighestBid: _ownHighestBid(domain),
     totalBids: getTotalBids(domain),
     totalMasks: getTotalMasks(domain),

--- a/app/pages/Auction/BidActionPanel/OpenBid.js
+++ b/app/pages/Auction/BidActionPanel/OpenBid.js
@@ -31,7 +31,7 @@ class OpenBid extends Component {
 
     try {
       await sendOpen();
-      this.props.showSuccess('Successfully opened bid! Check back in a few minutes to start bidding.');
+      this.props.showSuccess('Successfully opened auction! Check back in a few minutes to start bidding.');
       analytics.track('opened bid');
     } catch (e) {
       console.error(e);

--- a/app/pages/Auction/BidActionPanel/index.js
+++ b/app/pages/Auction/BidActionPanel/index.js
@@ -130,7 +130,6 @@ class BidActionPanel extends Component {
 export default withRouter(
   connect(
     (state) => ({
-      confirmedBalance: state.wallet.balance.confirmed,
       watchList: state.watching.names,
       currentBlock: state.node.chain.height,
       network: state.node.network,

--- a/app/utils/balances.js
+++ b/app/utils/balances.js
@@ -15,9 +15,3 @@ export function toBaseUnits(bal) {
 export function toDisplayUnits(bal) {
   return new BigNumber(bal).div(UNIT_DIVISOR).toFixed(DECIMALS);
 }
-
-export function displayUnlockedConfirmBalance(balance, withUnit) {
-  const {confirmed = 0, lockedConfirmed = 0} = balance || {};
-  const ret = new BigNumber(confirmed - lockedConfirmed).div(UNIT_DIVISOR).toFixed(DECIMALS);
-  return withUnit ? `${ret} HNS` : ret;
-}


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/120

### Changes
- "Total Balance" is now the "unconfirmed" balance from hsd (includes all coins confirmed or not)
- "Unlocked Balance" is replaced with "Spendable Balance" which is the total minus all locked coins (confirmed or not)
- TXs with multiple covenants are indicated with `(multiple)` tag.
- Covenant values are displayed by their change to the spendable balance:
  - REDEEM and REVEAL will increase it (green number with +)
  - UPDATE and RENEW don't affect it at all (black number with no sign)
  - BID decrease it (red number with -)
- Send modal Max Send value is the spendable balance.
- Fee estimation for max send is improved using `subtractFee` and `createTX()`

![Screen Shot 2020-04-22 at 6 19 20 PM](https://user-images.githubusercontent.com/2084648/80137234-f915ac80-8570-11ea-8137-9b35cc31a4c7.png)
