### PR TITLE
Fix bugs introduced in recent updates

### DIFF
--- a/app/components/Transactions/Transaction/index.js
+++ b/app/components/Transactions/Transaction/index.js
@@ -18,6 +18,7 @@ const UPDATE = 'UPDATE';
 const RENEW = 'RENEW';
 const REDEEM = 'REDEEM';
 const COINBASE = 'COINBASE';
+const REGISTER = 'REGISTER';
 
 class Transaction extends Component {
   static propTypes = {
@@ -45,7 +46,8 @@ class Transaction extends Component {
         (tx.type === RECEIVE
         || tx.type === COINBASE
         || tx.type === REVEAL
-        || tx.type === REDEEM)
+        || tx.type === REDEEM
+        || tx.type === REGISTER)
          && !tx.pending,
       'transaction__number--neutral':
         (tx.type === UPDATE
@@ -93,6 +95,9 @@ class Transaction extends Component {
     } else if (tx.type === UPDATE) {
       description = 'Updated Record';
       content = this.formatDomain(tx.meta.domain);
+    } else if (tx.type === REGISTER) {
+      description = 'Registered Name';
+      content = this.formatDomain(tx.meta.domain);
     } else if (tx.type === RENEW) {
       description = 'Renewed Domain';
       content = this.formatDomain(tx.meta.domain);
@@ -123,7 +128,7 @@ class Transaction extends Component {
         {tx.pending ? <em>(pending)</em> : null}
         {' '}
         {
-          tx.type === RECEIVE || tx.type === COINBASE || tx.type === REDEEM || tx.type === REVEAL ? '+'
+          tx.type === RECEIVE || tx.type === COINBASE || tx.type === REDEEM || tx.type === REVEAL || tx.type === REGISTER ? '+'
           : tx.type === UPDATE || tx.type === RENEW || tx.type === OPEN ? ''
           : '-'
         }

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -8,6 +8,7 @@ import isEqual from 'lodash.isequal';
 import { SET_NODE_INFO, SET_FEE_INFO, NEW_BLOCK_STATUS } from './nodeReducer';
 import { getNameInfo } from './names';
 import { getYourBids } from './bids';
+import { getWatching } from './watching';
 import { fetchTransactions, fetchWallet } from './walletActions';
 
 export function createBackgroundMonitor() {
@@ -103,14 +104,6 @@ function difference(setA, setB) {
 
 export const onNewBlock = () => async (dispatch, getState) => {
   let state = getState();
-  const isInitialized = await getInitializationState(state.node.network);
-  if (!isInitialized) {
-    return;
-  }
-
-  if (!state.wallet.initialized || !state.node.isRunning) {
-    return;
-  }
 
   dispatch({type: NEW_BLOCK_STATUS, payload: 'Updating fees...'});
   const newFees = await nodeClient.getFees();
@@ -130,7 +123,13 @@ export const onNewBlock = () => async (dispatch, getState) => {
   const bids = state.bids.yourBids;
   for (const bid of bids) {
     const name = bid.name;
-    dispatch({type: NEW_BLOCK_STATUS, payload: `Loading name: ${name}`});
+    dispatch({type: NEW_BLOCK_STATUS, payload: `Loading bids: ${name}`});
+    await dispatch(getNameInfo(name));
+  }
+
+  const watch = state.watching.names;
+  for (const name of watch) {
+    dispatch({type: NEW_BLOCK_STATUS, payload: `Loading watchlist: ${name}`});
     await dispatch(getNameInfo(name));
   }
 

--- a/app/ducks/node.js
+++ b/app/ducks/node.js
@@ -1,7 +1,10 @@
 import { clientStub } from '../background/node/client';
 import { getNetwork, setNetwork } from '../db/system';
-import { fetchWallet } from './walletActions';
+import { fetchWallet, fetchTransactions } from './walletActions';
+import { getWatching } from './watching';
 import * as logger from '../utils/logClient';
+import { onNewBlock } from './backgroundMonitor';
+
 import {
   END_NETWORK_CHANGE,
   SET_NODE_INFO,
@@ -37,6 +40,9 @@ export const start = (network) => async (dispatch, getState) => {
     });
     await dispatch(setNodeInfo());
     await dispatch(fetchWallet());
+    await dispatch(fetchTransactions());
+    await dispatch(getWatching(network));
+    await dispatch(onNewBlock());
   } catch (error) {
     dispatch({
       type: START_ERROR,

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -268,20 +268,22 @@ async function parseInputsOutputs(net, tx) {
 
     covAction = covenant.action;
 
-    // Special case for reveals, indicate how much
+    // Special case for reveals and registers, indicate how much
     // spendable balance is returning to the wallet
-    // as change from the mask on the bid.
-    if (covenant.action === 'REVEAL')
+    // as change from the mask on the bid, or the difference
+    // between the highest and second-highest bid.
+    if (covenant.action === 'REVEAL'
+        || covenant.action === 'REGISTER') {
       covValue += tx.inputs[i].value - output.value;
-    else
+    } else {
       covValue += output.value;
+    }
 
     // Renewals and Updates have a value, but it doesn't
     // affect the spendable balance of the wallet.
     // TODO: Transfer, Finalize, etc will eventually need to go here
     if (covenant.action === 'RENEW'
-        || covenant.action === 'REGISTER'
-        || covenant.action === 'UPDATE'){
+        || covenant.action === 'UPDATE') {
       covValue = 0;
     }
 
@@ -347,7 +349,7 @@ async function parseCovenant(net, covenant) {
       };
     case 'REGISTER':
       return {
-        type: 'UPDATE',
+        type: 'REGISTER',
         meta: {
           domain: await nameByHash(net, covenant),
           data: covenant.items[2],

--- a/app/ducks/watching.js
+++ b/app/ducks/watching.js
@@ -1,5 +1,6 @@
 import * as namesDb from '../db/names';
 import { getWatchlist, saveToWatchlist } from '../db/watching';
+import { getNameInfo } from './names';
 
 const SET_WATCHLIST = 'app/watching/setWatchlist';
 
@@ -10,7 +11,7 @@ const initialState = {
 export const getWatching = (network) => async dispatch => {
   const data = await getWatchlist(network);
 
-  dispatch({
+  await dispatch({
     type: SET_WATCHLIST,
     payload: Array.isArray(data) ? data : [],
   });
@@ -23,10 +24,12 @@ export const addName = (name, network) => async dispatch => {
   await namesDb.storeName(name);
   await saveToWatchlist(network, result);
 
-  dispatch({
+  await dispatch({
     type: SET_WATCHLIST,
     payload: result,
   });
+
+  await dispatch(getNameInfo(name));
 };
 
 export const removeName = (name, network) => async dispatch => {
@@ -35,7 +38,7 @@ export const removeName = (name, network) => async dispatch => {
   result = result.filter(n => n !== name);
   await saveToWatchlist(network, result);
   
-  dispatch({
+  await dispatch({
     type: SET_WATCHLIST,
     payload: result,
   })

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -52,7 +52,6 @@ class App extends Component {
   async componentDidMount() {
     this.setState({isLoading: true});
     await this.props.startNode();
-    await this.props.onNewBlock();
     this.props.watchActivity();
     setTimeout(() => this.setState({isLoading: false}), 1000)
   }

--- a/app/pages/Auction/BidActionPanel/OpenBid.js
+++ b/app/pages/Auction/BidActionPanel/OpenBid.js
@@ -36,7 +36,7 @@ class OpenBid extends Component {
     } catch (e) {
       console.error(e);
       logger.error(`Error received from OpenBid - sendOpen]\n\n${e.message}\n${e.stack}\n`);
-      this.props.showError(`Failed to open bid: ${e.message}`);
+      this.props.showError(`Failed to open auction: ${e.message}`);
     }
   };
 

--- a/app/pages/Auction/BidActionPanel/index.js
+++ b/app/pages/Auction/BidActionPanel/index.js
@@ -26,7 +26,6 @@ class BidActionPanel extends Component {
       }),
     }),
     network: PropTypes.string.isRequired,
-    getWatching: PropTypes.func.isRequired,
     watchDomain: PropTypes.func.isRequired,
     unwatchDomain: PropTypes.func.isRequired,
   };
@@ -135,7 +134,6 @@ export default withRouter(
       network: state.node.network,
     }),
     dispatch => ({
-      getWatching: (network) => dispatch(watchingActions.getWatching(network)),
       watchDomain: (name, network) => dispatch(watchingActions.addName(name, network)),
       unwatchDomain: (name, network) => dispatch(watchingActions.removeName(name, network)),
     }),

--- a/app/pages/Watching/index.js
+++ b/app/pages/Watching/index.js
@@ -28,10 +28,6 @@ class Watching extends Component {
     analytics.screenView('Watching');
   }
 
-  componentWillMount() {
-    this.props.getWatching(this.props.network);
-  }
-
   handleOnChange = e => this.setState({query: e.target.value});
 
   onDownload = () => {
@@ -207,7 +203,6 @@ export default withRouter(
       network: state.node.network,
     }),
     dispatch => ({
-      getWatching: (network) => dispatch(watchingActions.getWatching(network)),
       addName: (name, network) => dispatch(watchingActions.addName(name, network)),
       removeName: (name, network) => dispatch(watchingActions.removeName(name, network)),
     }),


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/134
Closes https://github.com/kyokan/bob-wallet/issues/135
Closes https://github.com/kyokan/bob-wallet/issues/136

Sorry for the monolith PR.

# 1: Reword "bid" to "auction"

# 2: Display spendable balance delta from REGISTER

### Examples:

### Revealing a masked bid, then registering a bid and receiving change from the second-highest bid:

![Screen Shot 2020-05-11 at 10 47 47 AM](https://user-images.githubusercontent.com/2084648/81596536-4461f480-9392-11ea-987a-508acf06df7d.png)

### Revealing an un-masked bid, then redeeming a losing bid:

![Screen Shot 2020-05-11 at 10 46 35 AM](https://user-images.githubusercontent.com/2084648/81596538-4461f480-9392-11ea-97aa-36650844c08e.png)

### Revealing an un-masked bid then registering a TIED bid for highest:

![Screen Shot 2020-05-11 at 10 46 14 AM](https://user-images.githubusercontent.com/2084648/81596539-4461f480-9392-11ea-9d5d-25577d8fff01.png)

### Revealing an un-masked bid then registering a winner with no other bids:

![Screen Shot 2020-05-11 at 10 46 05 AM](https://user-images.githubusercontent.com/2084648/81596540-44fa8b00-9392-11ea-82df-f81ad222f931.png)


# 3: Fix watchlist

https://github.com/kyokan/bob-wallet/pull/126 improved the way bids are handled but broke the way the watchlist and those name status are handled. They share a lot of the same logic, so just needed to apply the same process.

Also noticed another issue which is behavior when switching networks. I'm not sure it was working correctly before, because of the state in `doPoll()`. So now when we switch networks, everything is loaded into the store. The result is a slightly longer "loading node" time on boot, bt then everything else is nice and snappy.