### PR TITLE
Allow importing 128-bit entropy seeds

### DIFF
--- a/app/pages/Onboarding/ImportSeedEnterMnemonic/index.js
+++ b/app/pages/Onboarding/ImportSeedEnterMnemonic/index.js
@@ -75,7 +75,7 @@ export default class ImportSeedEnterMnemonic extends Component {
   }
 
   disableButton() {
-    let length = this.state.mnemonic.trim().split(' ').length;
+    const length = this.state.mnemonic.trim().split(' ').length;
     return !(length === 12 || length === 24);
   }
 }

--- a/app/pages/Onboarding/ImportSeedEnterMnemonic/index.js
+++ b/app/pages/Onboarding/ImportSeedEnterMnemonic/index.js
@@ -43,7 +43,7 @@ export default class ImportSeedEnterMnemonic extends Component {
           <div className="backup-warning__header_text">Import your recovery phrase</div>
 
           <div className="import_warning_text">
-            Enter your 24 word seed phrase that was assigned to you when you
+            Enter your 12- or 24-word seed phrase that was assigned to you when you
             created your previous wallet.
           </div>
           <div className="import-enter__textarea-container">
@@ -75,6 +75,7 @@ export default class ImportSeedEnterMnemonic extends Component {
   }
 
   disableButton() {
-    return this.state.mnemonic.trim().split(' ').length !== 24;
+    let length = this.state.mnemonic.trim().split(' ').length;
+    return !(length === 12 || length === 24);
   }
 }


### PR DESCRIPTION
Wallets created using old hsd nodes have 128-bit entropy, thus the seed phrase only have 12 words.

This PR allows importing such wallets.