### PR TITLE
Allow bids of 0 value and fix interpretation of bids with 0 value

### DIFF
--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -418,7 +418,7 @@ function getTotalBids(domain) {
   for (const {bid} of domain.bids) {
     if (bid.own) {
       // This is our bid, but we don't know its value
-      if (!bid.value)
+      if (bid.value == null)
         return -1;
 
       total += bid.value;

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import {consensus} from 'hsd/lib/protocol';
 import {
   AuctionPanel,
   AuctionPanelFooter,
@@ -105,6 +106,15 @@ class BidNow extends Component {
     }
   }
 
+  processValue = (val, field) => {
+    const value = val.match(/[0-9]*\.?[0-9]{0,6}/g)[0];
+    if (Number.isNaN(parseFloat(value)))
+      return;
+    if (value * consensus.COIN > consensus.MAX_MONEY)
+      return;
+    this.setState({[field]: value});
+  }
+
   render() {
     const {domain} = this.props;
 
@@ -162,6 +172,7 @@ class BidNow extends Component {
   renderBiddingView() {
     const {
       bidAmount,
+      disguiseAmount
     } = this.state;
 
     const {spendableBalance} = this.props;
@@ -174,9 +185,8 @@ class BidNow extends Component {
               <div className="domains__bid-now__form__row__label">Bid Amount:</div>
               <div className="domains__bid-now__form__row__input">
                 <input
-                  type="number"
                   placeholder="0.00"
-                  onChange={e => this.setState({bidAmount: e.target.value})}
+                  onChange={e => this.processValue(e.target.value, 'bidAmount')}
                   value={bidAmount}
                 />
               </div>
@@ -186,7 +196,8 @@ class BidNow extends Component {
           <button
             className="domains__bid-now__action__cta"
             onClick={() => this.setState({isReviewing: true})}
-            disabled={!(bidAmount > 0)}
+            // bid amount of zero is allowed as long as a disguise is used
+            disabled={bidAmount > 0 ? false : (disguiseAmount > 0 ? false : true)}
           >
             Review Bid
           </button>
@@ -225,9 +236,8 @@ class BidNow extends Component {
           </div>
           <div className="domains__bid-now__form__row__input">
             <input
-              type="number"
               placeholder="Optional"
-              onChange={e => this.setState({disguiseAmount: e.target.value})}
+              onChange={e => this.processValue(e.target.value, 'disguiseAmount')}
               value={disguiseAmount}
             />
           </div>

--- a/app/pages/Auction/BidHistory.js
+++ b/app/pages/Auction/BidHistory.js
@@ -61,12 +61,12 @@ export default class BidHistory extends Component {
               const bid = map[fromAddress];
               const {month, day, year} = bid.date;
               let bidValue = 'Hidden Until Reveal';
-              if (!bid.bid && bid.own) {
+              if (bid.bid == null && bid.own) {
                 bidValue = <RepairBid
                   bid={bid}
                 />;
               }
-              if (bid.bid)
+              if (bid.bid != null)
                 bidValue = displayBalance(bid.bid, true);
               return (
                 <tr key={fromAddress}>


### PR DESCRIPTION
Builds on top of #165 and together closes #163.

Requires https://github.com/handshake-org/hsd/pull/477 and SHOULD require https://github.com/handshake-org/hsd/pull/479

This improves the input checking for bid and disguise values. 

Users have tried sending bids with values like `0.00000000000001`, not getting an error, and then not realizing their bid value was actually `0` in this case. Users could also send `0` bids using CLI commands. These 0-value bids were misinterpreted by Bob as being falsey, leading to unexpected UI behavior.

This PR requires that bid and disguise values match a regex (6 decimal places max) and max value check.

It allows Bob users to send bids of `0` value but ONLY if there is a non-zero LOCKUP value. This is a bit of an easter-egg and I'm ok with that. (The "place bid" button won't enable unless a disguise is added). We can also try to anticipate the user's strategy and add a warning or other type of message...?

It is CRITICAL that https://github.com/handshake-org/hsd/pull/479 is included in Bob, otherwise users sending extremely low value lockups will experience their bids not relaying between peers and very likely never confirmed.