### PR TITLE
[#191] Catch undefined domain.info in MyDomain

### DIFF
--- a/app/pages/MyDomain/index.js
+++ b/app/pages/MyDomain/index.js
@@ -82,7 +82,9 @@ class MyDomain extends Component {
   }
 
   render() {
-    const {name, history, domain} = this.props;
+    const {name, history} = this.props;
+    const domain = this.props.domain || {};
+    const info = domain.info || {};
 
     return (
       <div className="my-domain">
@@ -103,7 +105,10 @@ class MyDomain extends Component {
           <DomainDetails name={name} />
         </Collapsible>
         <Collapsible className="my-domain__info-panel" title="Records">
-          <Records name={name} transferring={domain.info.transfer !== 0} />
+          <Records
+            name={name}
+            transferring={(info.transfer !== undefined) && (info.transfer !== 0)}
+          />
         </Collapsible>
         <Collapsible className="my-domain__info-panel" title="Your Bids" defaultCollapsed>
           {


### PR DESCRIPTION
In MyDomain, we currently check if the `domain` prop is defined in `renderRenewal` but do not in the component-level `render`.  This PR adds the same checks and fixes #191.