### PR TITLE
Show correct API for wallet node

### DIFF
--- a/app/background/wallet/client.js
+++ b/app/background/wallet/client.js
@@ -2,6 +2,7 @@ import { makeClient } from '../ipc/ipc';
 
 export const clientStub = ipcRendererInjector => makeClient(ipcRendererInjector, 'Wallet', [
   'start',
+  'getAPIKey',
   'getWalletInfo',
   'getAccountInfo',
   'getCoin',

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -69,6 +69,11 @@ class WalletService {
     }
   };
 
+  getAPIKey = async () => {
+    await this._ensureClient();
+    return this.walletApiKey;
+  }
+
   getWalletInfo = async () => {
     await this._ensureClient();
     return this.client.getInfo(WALLET_ID);
@@ -345,12 +350,13 @@ class WalletService {
 
     this.networkName = networkName;
     this.apiKey = apiKey;
+    this.walletApiKey = apiKey || crypto.randomBytes(20).toString('hex');
     this.network = network;
 
     const walletOptions = {
       network: network,
-      port: 12137,
-      apiKey: crypto.randomBytes(20).toString('hex'),
+      port: network.walletPort,
+      apiKey: this.walletApiKey,
     };
 
     const node = new WalletNode({
@@ -458,6 +464,7 @@ const methods = {
   start: async () => null,
   getWalletInfo: service.getWalletInfo,
   getAccountInfo: service.getAccountInfo,
+  getAPIKey: service.getAPIKey,
   getCoin: service.getCoin,
   getNames: service.getNames,
   createNewWallet: service.createNewWallet,

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -352,7 +352,6 @@ class WalletService {
     this.apiKey = apiKey;
     this.walletApiKey = apiKey || crypto.randomBytes(20).toString('hex');
     this.network = network;
-
     const walletOptions = {
       network: network,
       port: network.walletPort,

--- a/app/components/Anchor/index.js
+++ b/app/components/Anchor/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import {shell} from "electron";
+import "./index.scss";
+
+export default function Anchor(props) {
+  const {
+    href = '',
+    children,
+  } = props;
+
+  return (
+    <a
+      className="anchor"
+      onClick={() => shell.openExternal(href)}
+    >
+      {children}
+    </a>
+  )
+}

--- a/app/components/Anchor/index.scss
+++ b/app/components/Anchor/index.scss
@@ -1,0 +1,8 @@
+@import "../../variables";
+
+.anchor {
+  color: $azure-blue;
+  text-decoration: underline;
+  cursor: pointer;
+
+}

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -27,6 +27,7 @@ export const setWallet = opts => {
     address = '',
     type = NONE,
     balance = {},
+    apiKey = '',
   } = opts;
 
   return {
@@ -36,6 +37,7 @@ export const setWallet = opts => {
       address,
       type,
       balance,
+      apiKey,
     },
   };
 };
@@ -52,6 +54,7 @@ export const completeInitialization = (passphrase) => async (dispatch, getState)
 
 export const fetchWallet = () => async (dispatch, getState) => {
   const network = getState().node.network;
+
   const isInitialized = await getInitializationState(network);
 
   if (!isInitialized) {
@@ -66,6 +69,7 @@ export const fetchWallet = () => async (dispatch, getState) => {
   }
 
   const accountInfo = await walletClient.getAccountInfo();
+  const apiKey = await walletClient.getAPIKey();
   dispatch(setWallet({
     initialized: isInitialized,
     address: accountInfo && accountInfo.receiveAddress,
@@ -73,6 +77,7 @@ export const fetchWallet = () => async (dispatch, getState) => {
     balance: (accountInfo && accountInfo.balance) || {
       ...getInitialState().balance,
     },
+    apiKey,
   }));
 };
 

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -16,6 +16,7 @@ import {
   STOP_SYNC_WALLET,
   SYNC_WALLET_PROGRESS,
   UNLOCK_WALLET,
+  SET_API_KEY,
 } from './walletReducer';
 import { NEW_BLOCK_STATUS } from './nodeReducer';
 
@@ -49,6 +50,14 @@ export const completeInitialization = (passphrase) => async (dispatch, getState)
   await dispatch(fetchWallet());
   dispatch({
     type: UNLOCK_WALLET,
+  });
+};
+
+export const fetchWalletAPIKey = () => async (dispatch) => {
+  const apiKey = await walletClient.getAPIKey();
+  dispatch({
+    type: SET_API_KEY,
+    payload: apiKey,
   });
 };
 

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -14,6 +14,7 @@ export const START_SYNC_WALLET = 'app/wallet/startSyncWallet';
 export const STOP_SYNC_WALLET = 'app/wallet/stopSyncWallet';
 export const SYNC_WALLET_PROGRESS = 'app/wallet/syncWalletProgress';
 export const GET_PASSPHRASE = 'app/wallet/getPassphrase';
+export const SET_API_KEY = 'app/wallet/setApiKey';
 
 export function getInitialState() {
   return {
@@ -54,6 +55,11 @@ export default function walletReducer(state = getInitialState(), {type, payload}
         },
         initialized: payload.initialized,
         apiKey: payload.apiKey,
+      };
+    case SET_API_KEY:
+      return {
+        ...state,
+        apiKey: payload,
       };
     case LOCK_WALLET:
       return {

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -18,6 +18,7 @@ export const GET_PASSPHRASE = 'app/wallet/getPassphrase';
 export function getInitialState() {
   return {
     address: '',
+    apiKey: '',
     type: NONE,
     isLocked: true,
     initialized: false,
@@ -51,7 +52,8 @@ export default function walletReducer(state = getInitialState(), {type, payload}
           lockedConfirmed: payload.balance.lockedConfirmed,
           spendable: payload.balance.unconfirmed - payload.balance.lockedUnconfirmed,
         },
-        initialized: payload.initialized
+        initialized: payload.initialized,
+        apiKey: payload.apiKey,
       };
     case LOCK_WALLET:
       return {

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -21,6 +21,7 @@ import copy from "copy-to-clipboard";
 import {setCustomRPCStatus} from "../../ducks/node";
 import CustomRPCConfigModal from "./CustomRPCConfigModal";
 import {fetchWalletAPIKey} from "../../ducks/walletActions";
+import Anchor from "../../components/Anchor";
 
 const analytics = aClientStub(() => require('electron').ipcRenderer);
 
@@ -252,7 +253,9 @@ export default class Settings extends Component {
               )}
               {this.renderSection(
                 'API Key',
-                'API key for hsw-cli and hsw-rpc. Please make sure you select the wallet "allison"',
+                <span>
+                  API key for <Anchor href="https://hsd-dev.org/api-docs/#get-wallet-info">hsw-cli</Anchor> and <Anchor href="https://hsd-dev.org/api-docs/#selectwallet">hsw-rpc</Anchor>. Make sure you select the wallet id "allison".
+                </span>,
                 'View API Key',
                 () => history.push('/settings/wallet/view-api-key'),
               )}

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -20,6 +20,7 @@ import MiniModal from "../../components/Modal/MiniModal";
 import copy from "copy-to-clipboard";
 import {setCustomRPCStatus} from "../../ducks/node";
 import CustomRPCConfigModal from "./CustomRPCConfigModal";
+import {fetchWalletAPIKey} from "../../ducks/walletActions";
 
 const analytics = aClientStub(() => require('electron').ipcRenderer);
 
@@ -39,12 +40,14 @@ const analytics = aClientStub(() => require('electron').ipcRenderer);
     stopNode: () => dispatch(nodeActions.stop()),
     startNode: () => dispatch(nodeActions.start()),
     setCustomRPCStatus: isConnected => dispatch(setCustomRPCStatus(isConnected)),
+    fetchWalletAPIKey: () => dispatch(fetchWalletAPIKey()),
   }),
 )
 export default class Settings extends Component {
   static propTypes = {
     network: PropTypes.string.isRequired,
     apiKey: PropTypes.string.isRequired,
+    walletApiKey: PropTypes.string.isRequired,
     isRunning: PropTypes.bool.isRequired,
     isChangingNodeStatus: PropTypes.bool.isRequired,
     lockWallet: PropTypes.func.isRequired,
@@ -56,6 +59,7 @@ export default class Settings extends Component {
 
   componentDidMount() {
     analytics.screenView('Settings');
+    this.props.fetchWalletAPIKey();
   }
 
   onDownload = async () => {
@@ -291,10 +295,10 @@ export default class Settings extends Component {
               <input
                 type="text"
                 className="settings__copy-api-key"
-                value={this.props.apiKey}
+                value={this.props.walletApiKey}
                 readOnly
               />
-              <button className="settings__btn" onClick={() => copy(this.props.apiKey)}>
+              <button className="settings__btn" onClick={() => copy(this.props.walletApiKey)}>
                 Copy
               </button>
             </MiniModal>

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -28,6 +28,7 @@ const analytics = aClientStub(() => require('electron').ipcRenderer);
   (state) => ({
     network: state.node.network,
     apiKey: state.node.apiKey,
+    walletApiKey: state.wallet.apiKey,
     isRunning: state.node.isRunning,
     isChangingNodeStatus: state.node.isChangingNodeStatus,
     isTestingCustomRPC: state.node.isTestingCustomRPC,
@@ -245,6 +246,12 @@ export default class Settings extends Component {
                 'Remove Wallet ',
                 () => history.push('/settings/wallet/new-wallet'),
               )}
+              {this.renderSection(
+                'API Key',
+                'API key for hsw-cli and hsw-rpc. Please make sure you select the wallet "allison"',
+                'View API Key',
+                () => history.push('/settings/wallet/view-api-key'),
+              )}
             </>
           </Route>
           <Route>
@@ -274,6 +281,23 @@ export default class Settings extends Component {
           <Route path="/settings/wallet/reveal-seed" component={RevealSeedModal} />
           <Route path="/settings/wallet/zap-txs" component={ZapTXsModal} />
           <Route path="/settings/connection/configure" component={CustomRPCConfigModal}>
+          </Route>
+          <Route path="/settings/wallet/view-api-key">
+            <MiniModal
+              closeRoute="/settings/wallet"
+              title="Wallet API Key"
+              centered
+            >
+              <input
+                type="text"
+                className="settings__copy-api-key"
+                value={this.props.apiKey}
+                readOnly
+              />
+              <button className="settings__btn" onClick={() => copy(this.props.apiKey)}>
+                Copy
+              </button>
+            </MiniModal>
           </Route>
           <Route path="/settings/connection/view-api-key">
             <MiniModal


### PR DESCRIPTION
Hotfix for _invalid wallet api key_ issue reported by @pinheadmz on Telegram.

This add a new panel in setting for user to grab the valid api key. If the user use custom RPC, it would generate its own api key instead.

Also added a description below to remind user to always choose the wallet **allison**

![Screen Shot 2020-08-12 at 8 12 28 PM](https://user-images.githubusercontent.com/8507735/90090638-604e9c80-dcd9-11ea-9680-41ae22698ccc.png)
