### PR TITLE
Rescan Button and various fixes

### DIFF
--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -159,6 +159,11 @@ class WalletService {
     return new Promise(async (resolve, reject) => {
       const intv = setInterval(async () => {
         const { height: walletHeight } = await wdb.getTip();
+
+        if (walletHeight < chainHeight) {
+          resetting = false;
+        }
+
         dispatchToMainWindow({
           type: SYNC_WALLET_PROGRESS,
           payload: resetting

--- a/app/components/Sidebar/index.js
+++ b/app/components/Sidebar/index.js
@@ -12,6 +12,8 @@ import { Logo } from '../Logo';
     height: state.node.chain.height,
     tip: state.node.chain.tip,
     newBlockStatus: state.node.newBlockStatus,
+    walletSync: state.wallet.walletSync,
+    walletSyncProgress: state.wallet.walletSyncProgress,
   }),
   dispatch => ({})
 )
@@ -26,6 +28,8 @@ class Sidebar extends Component {
     height: PropTypes.number.isRequired,
     tip: PropTypes.string.isRequired,
     newBlockStatus: PropTypes.string.isRequired,
+    walletSync: PropTypes.bool.isRequired,
+    walletSyncProgress: PropTypes.number.isRequired,
   };
 
   render() {
@@ -118,6 +122,11 @@ class Sidebar extends Component {
   }
 
   renderFooter() {
+    const {
+      walletSync,
+      walletSyncProgress,
+    } = this.props;
+
     return (
       <div className="sidebar__footer">
         <div className="sidebar__footer__row">
@@ -126,7 +135,11 @@ class Sidebar extends Component {
         <div className="sidebar__footer__row">
           <div className="sidebar__footer__title">Current Height</div>
           <div className="sidebar__footer__text">
-            {this.props.height || '--'}
+            {
+              walletSync
+                ? `${Math.floor((walletSyncProgress/100) * this.props.height)}/${this.props.height}`
+                : this.props.height || '--'
+            }
           </div>
         </div>
         <div className="sidebar__footer__row">

--- a/app/components/Topbar/index.js
+++ b/app/components/Topbar/index.js
@@ -32,6 +32,8 @@ import * as walletActions from '../../ducks/walletActions';
       progress,
       unconfirmedBalance: state.wallet.balance.unconfirmed,
       spendableBalance: state.wallet.balance.spendable,
+      walletSync: state.wallet.walletSync,
+      walletSyncProgress: state.wallet.walletSyncProgress,
     };
   },
   dispatch => ({
@@ -56,6 +58,8 @@ class Topbar extends Component {
     spendableBalance: PropTypes.number,
     isChangingNodeStatus: PropTypes.bool.isRequired,
     isTestingCustomRPC: PropTypes.bool.isRequired,
+    walletSync: PropTypes.bool.isRequired,
+    walletSyncProgress: PropTypes.number.isRequired,
   };
 
   state = {
@@ -116,7 +120,8 @@ class Topbar extends Component {
       isRunning,
       isCustomRPCConnected,
       showLogo,
-      location: { pathname }
+      location: { pathname },
+      walletSync,
     } = this.props;
 
     return (
@@ -127,7 +132,7 @@ class Topbar extends Component {
           className={c('topbar__synced', {
             'topbar__synced--success': isSynchronized || isCustomRPCConnected,
             'topbar__synced--failure': !isRunning && !isCustomRPCConnected,
-            'topbar__synced--loading': isChangingNodeStatus || isTestingCustomRPC || isSynchronizing,
+            'topbar__synced--loading': walletSync || isChangingNodeStatus || isTestingCustomRPC || isSynchronizing,
           })}
         >
           {this.getSyncText()}
@@ -205,12 +210,18 @@ class Topbar extends Component {
       isCustomRPCConnected,
       isChangingNodeStatus,
       isTestingCustomRPC,
+      walletSync,
+      walletSyncProgress,
     } = this.props;
 
     if (isSynchronizing) {
       return `Synchronizing... ${
         progress ? '(' + (progress * 100).toFixed(2) + '%)' : ''
       }`;
+    }
+
+    if (walletSync) {
+      return `Rescanning... (${walletSyncProgress}%)`;
     }
 
     if (isSynchronized) {

--- a/app/components/Transactions/index.js
+++ b/app/components/Transactions/index.js
@@ -38,7 +38,7 @@ const ITEM_PER_DROPDOWN = [
 )
 export default class Transactions extends Component {
   static propTypes = {
-    transactions: PropTypes.instanceOf(Map).isRequired
+    transactions: PropTypes.instanceOf(Map).isRequired,
   };
 
   async componentDidMount() {

--- a/app/components/Transactions/index.scss
+++ b/app/components/Transactions/index.scss
@@ -121,6 +121,7 @@
 
 .transactions {
   @extend %col-nowrap;
+  position: relative;
 
   &__empty-list {
     text-align: center;

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -8,7 +8,6 @@ import isEqual from 'lodash.isequal';
 import { SET_NODE_INFO, SET_FEE_INFO, NEW_BLOCK_STATUS } from './nodeReducer';
 import { getNameInfo } from './names';
 import { getYourBids } from './bids';
-import { getWatching } from './watching';
 import { fetchTransactions, fetchWallet } from './walletActions';
 
 export function createBackgroundMonitor() {
@@ -33,48 +32,48 @@ export function createBackgroundMonitor() {
       return;
     }
 
-    // const infoRes = await nodeClient.getInfo();
-    // const newInfo = {
-    //   chain: infoRes.chain,
-    //   network: infoRes.network,
-    // };
-    //
-    // if (!isEqual(info, newInfo)) {
-    //   info = newInfo;
-    //   store.dispatch({
-    //     type: SET_NODE_INFO,
-    //     payload: {
-    //       info: newInfo,
-    //     },
-    //   });
-    // }
-    //
-    // if (state.node.chain.tip !== infoRes.chain.tip)
-    //   await store.dispatch(onNewBlock());
-    //
-    // const newPendingTxns = await walletClient.getPendingTransactions();
-    // store.dispatch({
-    //   type: SET_PENDING_TRANSACTIONS,
-    //   payload: newPendingTxns,
-    // });
-    //
-    // await store.dispatch(fetchWallet());
-    // await store.dispatch(fetchTransactions());
-    //
-    // // once a pending name operation is no longer pending,
-    // // refresh that name's state.
-    // state = store.getState();
-    // const currentNamesWithPendingUpdates = new Set();
-    // Object.keys(state.names).filter((k) => {
-    //   const domain = state.names[k];
-    //   return domain.pendingOperation === 'UPDATE' || domain.pendingOperation === 'REGISTER';
-    // }).forEach((name) => currentNamesWithPendingUpdates.add(name));
-    //
-    // const noLongerPending = difference(prevNamesWithPendingUpdates, currentNamesWithPendingUpdates);
-    // for (const name of noLongerPending) {
-    //   await store.dispatch(getNameInfo(name));
-    // }
-    // prevNamesWithPendingUpdates = currentNamesWithPendingUpdates;
+    const infoRes = await nodeClient.getInfo();
+    const newInfo = {
+      chain: infoRes.chain,
+      network: infoRes.network,
+    };
+
+    if (!isEqual(info, newInfo)) {
+      info = newInfo;
+      store.dispatch({
+        type: SET_NODE_INFO,
+        payload: {
+          info: newInfo,
+        },
+      });
+    }
+
+    if (state.node.chain.tip !== infoRes.chain.tip)
+      await store.dispatch(onNewBlock());
+
+    const newPendingTxns = await walletClient.getPendingTransactions();
+    store.dispatch({
+      type: SET_PENDING_TRANSACTIONS,
+      payload: newPendingTxns,
+    });
+
+    await store.dispatch(fetchWallet());
+    await store.dispatch(fetchTransactions());
+
+    // once a pending name operation is no longer pending,
+    // refresh that name's state.
+    state = store.getState();
+    const currentNamesWithPendingUpdates = new Set();
+    Object.keys(state.names).filter((k) => {
+      const domain = state.names[k];
+      return domain.pendingOperation === 'UPDATE' || domain.pendingOperation === 'REGISTER';
+    }).forEach((name) => currentNamesWithPendingUpdates.add(name));
+
+    const noLongerPending = difference(prevNamesWithPendingUpdates, currentNamesWithPendingUpdates);
+    for (const name of noLongerPending) {
+      await store.dispatch(getNameInfo(name));
+    }
+    prevNamesWithPendingUpdates = currentNamesWithPendingUpdates;
   };
 
   const poll = async () => {
@@ -110,46 +109,46 @@ function difference(setA, setB) {
 }
 
 export const onNewBlock = () => async (dispatch, getState) => {
-  // let state = getState();
-  //
-  // dispatch({type: NEW_BLOCK_STATUS, payload: 'Updating fees...'});
-  // const newFees = await nodeClient.getFees();
-  // if (!isEqual(state.node.fees, newFees)) {
-  //   dispatch({
-  //     type: SET_FEE_INFO,
-  //     payload: {
-  //       fees: newFees,
-  //     },
-  //   });
-  // }
-  //
-  // dispatch({type: NEW_BLOCK_STATUS, payload: 'Loading bids...'});
-  // await dispatch(getYourBids());
-  // state = getState();
-  //
-  // const names = {};
-  // const bids = state.bids.yourBids;
-  //
-  // for (const bid of bids) {
-  //   const name = bid.name;
-  //   names[name] = name;
-  // }
-  //
-  // const watch = state.watching.names;
-  // for (const name of watch) {
-  //   names[name] = name;
-  // }
-  //
-  // const namesList = Object.keys(names);
-  // for (let i = 0; i < namesList.length; i++) {
-  //   await dispatch(getNameInfo(namesList[i]));
-  //   dispatch({
-  //     type: NEW_BLOCK_STATUS,
-  //     payload: `Loading ${i} of ${namesList.length} names`,
-  //   });
-  // }
-  //
-  // dispatch({type: NEW_BLOCK_STATUS, payload: ''});
-}
+  let state = getState();
+
+  dispatch({type: NEW_BLOCK_STATUS, payload: 'Updating fees...'});
+  const newFees = await nodeClient.getFees();
+  if (!isEqual(state.node.fees, newFees)) {
+    dispatch({
+      type: SET_FEE_INFO,
+      payload: {
+        fees: newFees,
+      },
+    });
+  }
+
+  dispatch({type: NEW_BLOCK_STATUS, payload: 'Loading bids...'});
+  await dispatch(getYourBids());
+  state = getState();
+
+  const names = {};
+  const bids = state.bids.yourBids;
+
+  for (const bid of bids) {
+    const name = bid.name;
+    names[name] = name;
+  }
+
+  const watch = state.watching.names;
+  for (const name of watch) {
+    names[name] = name;
+  }
+
+  const namesList = Object.keys(names);
+  for (let i = 0; i < namesList.length; i++) {
+    await dispatch(getNameInfo(namesList[i]));
+    dispatch({
+      type: NEW_BLOCK_STATUS,
+      payload: `Loading ${i} of ${namesList.length} names`,
+    });
+  }
+
+  dispatch({type: NEW_BLOCK_STATUS, payload: ''});
+};
 
 export const monitor = createBackgroundMonitor();

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -33,48 +33,48 @@ export function createBackgroundMonitor() {
       return;
     }
 
-    const infoRes = await nodeClient.getInfo();
-    const newInfo = {
-      chain: infoRes.chain,
-      network: infoRes.network,
-    };
-
-    if (!isEqual(info, newInfo)) {
-      info = newInfo;
-      store.dispatch({
-        type: SET_NODE_INFO,
-        payload: {
-          info: newInfo,
-        },
-      });
-    }
-
-    if (state.node.chain.tip !== infoRes.chain.tip)
-      await store.dispatch(onNewBlock());
-
-    const newPendingTxns = await walletClient.getPendingTransactions();
-    store.dispatch({
-      type: SET_PENDING_TRANSACTIONS,
-      payload: newPendingTxns,
-    });
-
-    await store.dispatch(fetchWallet());
-    await store.dispatch(fetchTransactions());
-
-    // once a pending name operation is no longer pending,
-    // refresh that name's state.
-    state = store.getState();
-    const currentNamesWithPendingUpdates = new Set();
-    Object.keys(state.names).filter((k) => {
-      const domain = state.names[k];
-      return domain.pendingOperation === 'UPDATE' || domain.pendingOperation === 'REGISTER';
-    }).forEach((name) => currentNamesWithPendingUpdates.add(name));
-
-    const noLongerPending = difference(prevNamesWithPendingUpdates, currentNamesWithPendingUpdates);
-    for (const name of noLongerPending) {
-      await store.dispatch(getNameInfo(name));
-    }
-    prevNamesWithPendingUpdates = currentNamesWithPendingUpdates;
+    // const infoRes = await nodeClient.getInfo();
+    // const newInfo = {
+    //   chain: infoRes.chain,
+    //   network: infoRes.network,
+    // };
+    //
+    // if (!isEqual(info, newInfo)) {
+    //   info = newInfo;
+    //   store.dispatch({
+    //     type: SET_NODE_INFO,
+    //     payload: {
+    //       info: newInfo,
+    //     },
+    //   });
+    // }
+    //
+    // if (state.node.chain.tip !== infoRes.chain.tip)
+    //   await store.dispatch(onNewBlock());
+    //
+    // const newPendingTxns = await walletClient.getPendingTransactions();
+    // store.dispatch({
+    //   type: SET_PENDING_TRANSACTIONS,
+    //   payload: newPendingTxns,
+    // });
+    //
+    // await store.dispatch(fetchWallet());
+    // await store.dispatch(fetchTransactions());
+    //
+    // // once a pending name operation is no longer pending,
+    // // refresh that name's state.
+    // state = store.getState();
+    // const currentNamesWithPendingUpdates = new Set();
+    // Object.keys(state.names).filter((k) => {
+    //   const domain = state.names[k];
+    //   return domain.pendingOperation === 'UPDATE' || domain.pendingOperation === 'REGISTER';
+    // }).forEach((name) => currentNamesWithPendingUpdates.add(name));
+    //
+    // const noLongerPending = difference(prevNamesWithPendingUpdates, currentNamesWithPendingUpdates);
+    // for (const name of noLongerPending) {
+    //   await store.dispatch(getNameInfo(name));
+    // }
+    // prevNamesWithPendingUpdates = currentNamesWithPendingUpdates;
   };
 
   const poll = async () => {
@@ -110,46 +110,46 @@ function difference(setA, setB) {
 }
 
 export const onNewBlock = () => async (dispatch, getState) => {
-  let state = getState();
-
-  dispatch({type: NEW_BLOCK_STATUS, payload: 'Updating fees...'});
-  const newFees = await nodeClient.getFees();
-  if (!isEqual(state.node.fees, newFees)) {
-    dispatch({
-      type: SET_FEE_INFO,
-      payload: {
-        fees: newFees,
-      },
-    });
-  }
-
-  dispatch({type: NEW_BLOCK_STATUS, payload: 'Loading bids...'});
-  await dispatch(getYourBids());
-  state = getState();
-
-  const names = {};
-  const bids = state.bids.yourBids;
-
-  for (const bid of bids) {
-    const name = bid.name;
-    names[name] = name;
-  }
-
-  const watch = state.watching.names;
-  for (const name of watch) {
-    names[name] = name;
-  }
-
-  const namesList = Object.keys(names);
-  for (let i = 0; i < namesList.length; i++) {
-    await dispatch(getNameInfo(namesList[i]));
-    dispatch({
-      type: NEW_BLOCK_STATUS,
-      payload: `Loading ${i} of ${namesList.length} names`,
-    });
-  }
-
-  dispatch({type: NEW_BLOCK_STATUS, payload: ''});
+  // let state = getState();
+  //
+  // dispatch({type: NEW_BLOCK_STATUS, payload: 'Updating fees...'});
+  // const newFees = await nodeClient.getFees();
+  // if (!isEqual(state.node.fees, newFees)) {
+  //   dispatch({
+  //     type: SET_FEE_INFO,
+  //     payload: {
+  //       fees: newFees,
+  //     },
+  //   });
+  // }
+  //
+  // dispatch({type: NEW_BLOCK_STATUS, payload: 'Loading bids...'});
+  // await dispatch(getYourBids());
+  // state = getState();
+  //
+  // const names = {};
+  // const bids = state.bids.yourBids;
+  //
+  // for (const bid of bids) {
+  //   const name = bid.name;
+  //   names[name] = name;
+  // }
+  //
+  // const watch = state.watching.names;
+  // for (const name of watch) {
+  //   names[name] = name;
+  // }
+  //
+  // const namesList = Object.keys(names);
+  // for (let i = 0; i < namesList.length; i++) {
+  //   await dispatch(getNameInfo(namesList[i]));
+  //   dispatch({
+  //     type: NEW_BLOCK_STATUS,
+  //     payload: `Loading ${i} of ${namesList.length} names`,
+  //   });
+  // }
+  //
+  // dispatch({type: NEW_BLOCK_STATUS, payload: ''});
 }
 
 export const monitor = createBackgroundMonitor();

--- a/app/ducks/backgroundMonitor.js
+++ b/app/ducks/backgroundMonitor.js
@@ -19,11 +19,17 @@ export function createBackgroundMonitor() {
   const doPoll = async () => {
     let state = store.getState();
     const isInitialized = await getInitializationState(state.node.network);
+
     if (!isInitialized) {
       return;
     }
 
-    if (!state.wallet.initialized || !state.node.isRunning) {
+    const {
+      wallet: { initialized },
+      node: { isRunning, isCustomRPCConnected },
+    } = state;
+
+    if (!initialized || (!isRunning && !isCustomRPCConnected)) {
       return;
     }
 
@@ -32,6 +38,7 @@ export function createBackgroundMonitor() {
       chain: infoRes.chain,
       network: infoRes.network,
     };
+
     if (!isEqual(info, newInfo)) {
       info = newInfo;
       store.dispatch({
@@ -78,7 +85,7 @@ export function createBackgroundMonitor() {
       logger.error(`[Error received from backgroundMonitor.js - poll\n\n${e.message}\n${e.stack}\n`);
     }
 
-    timeout = setTimeout(poll, 10000);
+    timeout = setTimeout(poll, 60000);
   };
 
   return {
@@ -118,19 +125,28 @@ export const onNewBlock = () => async (dispatch, getState) => {
 
   dispatch({type: NEW_BLOCK_STATUS, payload: 'Loading bids...'});
   await dispatch(getYourBids());
-  
   state = getState();
+
+  const names = {};
   const bids = state.bids.yourBids;
+
   for (const bid of bids) {
     const name = bid.name;
-    dispatch({type: NEW_BLOCK_STATUS, payload: `Loading bids: ${name}`});
-    await dispatch(getNameInfo(name));
+    names[name] = name;
   }
 
   const watch = state.watching.names;
   for (const name of watch) {
-    dispatch({type: NEW_BLOCK_STATUS, payload: `Loading watchlist: ${name}`});
-    await dispatch(getNameInfo(name));
+    names[name] = name;
+  }
+
+  const namesList = Object.keys(names);
+  for (let i = 0; i < namesList.length; i++) {
+    await dispatch(getNameInfo(namesList[i]));
+    dispatch({
+      type: NEW_BLOCK_STATUS,
+      payload: `Loading ${i} of ${namesList.length} names`,
+    });
   }
 
   dispatch({type: NEW_BLOCK_STATUS, payload: ''});

--- a/app/ducks/bids.js
+++ b/app/ducks/bids.js
@@ -1,4 +1,6 @@
 import walletClient from '../utils/walletClient';
+import {NEW_BLOCK_STATUS} from "./nodeReducer";
+import {getNameInfo} from "./names";
 
 const SET_YOUR_BIDS = 'app/bids/setYourBids';
 

--- a/app/ducks/myDomains.js
+++ b/app/ducks/myDomains.js
@@ -20,21 +20,25 @@ export const getMyNames = () => async (dispatch, getState) => {
     const result = await walletClient.getNames();
     const ret = [];
 
-    if (address) {
-      await Promise.all(result.map(async domain => {
-        const {owner} = domain;
-        const coin = await walletClient.getCoin(owner.hash, owner.index);
+    for (let i = 0; i < result.length; i++) {
+      const domain = result[i];
+      const {owner} = domain;
+      const coin = await walletClient.getCoin(owner.hash, owner.index);
 
-        if (coin && domain.state === 'CLOSED') {
-          ret.push(domain);
-        }
-      }));
+      if (coin && domain.state === 'CLOSED') {
+        ret.push(domain);
+        dispatch({
+          type: FETCH_MY_NAMES_STOP,
+          payload: ret.slice(),
+        });
+      }
     }
 
-    dispatch({
-      type: FETCH_MY_NAMES_STOP,
-      payload: ret,
-    });
+    // console.log(ret);
+    // dispatch({
+    //   type: FETCH_MY_NAMES_STOP,
+    //   payload: ret,
+    // });
   } catch (error) {
     dispatch({
       type: FETCH_MY_NAMES_STOP,

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -16,7 +16,7 @@ import {
   STOP_SYNC_WALLET,
   SYNC_WALLET_PROGRESS,
   UNLOCK_WALLET,
-  SET_API_KEY,
+  SET_API_KEY, SET_FETCHING,
 } from './walletReducer';
 import { NEW_BLOCK_STATUS } from './nodeReducer';
 
@@ -175,6 +175,12 @@ export const fetchTransactions = () => async (dispatch, getState) => {
   const state = getState();
   const net = state.node.network;
   const currentTXs = state.wallet.transactions;
+
+  dispatch({
+    type: SET_FETCHING,
+    payload: true,
+  });
+
   const txs = await walletClient.getTransactionHistory();
   let payload = new Map();
 
@@ -205,6 +211,11 @@ export const fetchTransactions = () => async (dispatch, getState) => {
 
   // Sort all TXs by date without losing the hash->tx mapping
   payload = new Map([...payload.entries()].sort((a, b) => b[1].date - a[1].date));
+
+  dispatch({
+    type: SET_FETCHING,
+    payload: false,
+  });
 
   dispatch({
     type: SET_TRANSACTIONS,

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -133,42 +133,42 @@ export const stopWalletSync = () => async (dispatch) => {
 };
 
 export const waitForWalletSync = () => async (dispatch, getState) => {
-  // let lastProgress = 0;
-  // let stall = 0;
-  //
-  // for (; ;) {
-  //   const nodeInfo = await nodeClient.getInfo();
-  //   const wdbInfo = await walletClient.rpcGetWalletInfo();
-  //
-  //   if (nodeInfo.chain.height === 0) {
-  //     dispatch({type: STOP_SYNC_WALLET});
-  //     break;
-  //   }
-  //
-  //   const progress = parseInt(wdbInfo.height / nodeInfo.chain.height * 100);
-  //
-  //   // If we go 5 seconds without any progress, throw an error
-  //   if (lastProgress === progress) {
-  //     stall++;
-  //   } else {
-  //     lastProgress = progress;
-  //     stall = 0;
-  //   }
-  //
-  //   if (stall >= 5) {
-  //     dispatch({type: STOP_SYNC_WALLET});
-  //     throw new Error('Wallet sync progress has stalled.');
-  //   }
-  //
-  //   if (progress === 100) {
-  //     dispatch({type: STOP_SYNC_WALLET});
-  //     break;
-  //   } else {
-  //     dispatch({type: SYNC_WALLET_PROGRESS, payload: progress});
-  //   }
-  //
-  //   await new Promise((r) => setTimeout(r, 10000));
-  // }
+  let lastProgress = 0;
+  let stall = 0;
+
+  for (; ;) {
+    const nodeInfo = await nodeClient.getInfo();
+    const wdbInfo = await walletClient.rpcGetWalletInfo();
+
+    if (nodeInfo.chain.height === 0) {
+      dispatch({type: STOP_SYNC_WALLET});
+      break;
+    }
+
+    const progress = parseInt(wdbInfo.height / nodeInfo.chain.height * 100);
+
+    // If we go 5 seconds without any progress, throw an error
+    if (lastProgress === progress) {
+      stall++;
+    } else {
+      lastProgress = progress;
+      stall = 0;
+    }
+
+    if (stall >= 5) {
+      dispatch({type: STOP_SYNC_WALLET});
+      throw new Error('Wallet sync progress has stalled.');
+    }
+
+    if (progress === 100) {
+      dispatch({type: STOP_SYNC_WALLET});
+      break;
+    } else {
+      dispatch({type: SYNC_WALLET_PROGRESS, payload: progress});
+    }
+
+    await new Promise((r) => setTimeout(r, 10000));
+  }
 };
 
 export const fetchTransactions = () => async (dispatch, getState) => {

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -265,7 +265,7 @@ async function parseInputsOutputs(net, tx) {
     const output = tx.outputs[i];
 
     // Find outputs to the wallet's receive branch
-    if (!output.path || output.path.change)
+    if (output.path && output.path.change)
       continue;
 
     const covenant = output.covenant;
@@ -287,7 +287,9 @@ async function parseInputsOutputs(net, tx) {
     // between the highest and second-highest bid.
     if (covenant.action === 'REVEAL'
       || covenant.action === 'REGISTER') {
-      covValue += tx.inputs[i].value - output.value;
+      covValue += !output.path
+        ? output.value
+        : tx.inputs[i].value - output.value;
     } else {
       covValue += output.value;
     }

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -133,42 +133,42 @@ export const stopWalletSync = () => async (dispatch) => {
 };
 
 export const waitForWalletSync = () => async (dispatch, getState) => {
-  let lastProgress = 0;
-  let stall = 0;
-
-  for (; ;) {
-    const nodeInfo = await nodeClient.getInfo();
-    const wdbInfo = await walletClient.rpcGetWalletInfo();
-
-    if (nodeInfo.chain.height === 0) {
-      dispatch({type: STOP_SYNC_WALLET});
-      break;
-    }
-
-    const progress = parseInt(wdbInfo.height / nodeInfo.chain.height * 100);
-
-    // If we go 5 seconds without any progress, throw an error
-    if (lastProgress === progress) {
-      stall++;
-    } else {
-      lastProgress = progress;
-      stall = 0;
-    }
-
-    if (stall >= 5) {
-      dispatch({type: STOP_SYNC_WALLET});
-      throw new Error('Wallet sync progress has stalled.');
-    }
-
-    if (progress === 100) {
-      dispatch({type: STOP_SYNC_WALLET});
-      break;
-    } else {
-      dispatch({type: SYNC_WALLET_PROGRESS, payload: progress});
-    }
-
-    await new Promise((r) => setTimeout(r, 10000));
-  }
+  // let lastProgress = 0;
+  // let stall = 0;
+  //
+  // for (; ;) {
+  //   const nodeInfo = await nodeClient.getInfo();
+  //   const wdbInfo = await walletClient.rpcGetWalletInfo();
+  //
+  //   if (nodeInfo.chain.height === 0) {
+  //     dispatch({type: STOP_SYNC_WALLET});
+  //     break;
+  //   }
+  //
+  //   const progress = parseInt(wdbInfo.height / nodeInfo.chain.height * 100);
+  //
+  //   // If we go 5 seconds without any progress, throw an error
+  //   if (lastProgress === progress) {
+  //     stall++;
+  //   } else {
+  //     lastProgress = progress;
+  //     stall = 0;
+  //   }
+  //
+  //   if (stall >= 5) {
+  //     dispatch({type: STOP_SYNC_WALLET});
+  //     throw new Error('Wallet sync progress has stalled.');
+  //   }
+  //
+  //   if (progress === 100) {
+  //     dispatch({type: STOP_SYNC_WALLET});
+  //     break;
+  //   } else {
+  //     dispatch({type: SYNC_WALLET_PROGRESS, payload: progress});
+  //   }
+  //
+  //   await new Promise((r) => setTimeout(r, 10000));
+  // }
 };
 
 export const fetchTransactions = () => async (dispatch, getState) => {

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -15,6 +15,7 @@ export const STOP_SYNC_WALLET = 'app/wallet/stopSyncWallet';
 export const SYNC_WALLET_PROGRESS = 'app/wallet/syncWalletProgress';
 export const GET_PASSPHRASE = 'app/wallet/getPassphrase';
 export const SET_API_KEY = 'app/wallet/setApiKey';
+export const SET_FETCHING = 'app/wallet/setFetching';
 
 export function getInitialState() {
   return {
@@ -22,6 +23,7 @@ export function getInitialState() {
     apiKey: '',
     type: NONE,
     isLocked: true,
+    isFetching: false,
     initialized: false,
     network: '',
     balance: {
@@ -105,6 +107,11 @@ export default function walletReducer(state = getInitialState(), {type, payload}
       return {
         ...state,
         getPassphrase: payload,
+      };
+    case SET_FETCHING:
+      return {
+        ...state,
+        isFetching: payload,
       };
     default:
       return state;

--- a/app/index.js
+++ b/app/index.js
@@ -8,12 +8,19 @@ import { history, store } from './store/configureStore';
 import './global.scss';
 import { monitor } from './ducks/backgroundMonitor';
 import { showError } from './ducks/notifications';
+import {ipcRenderer} from "electron";
 
 window.addEventListener('error', (e) => {
   store.dispatch(showError(e.message));
 });
 
 monitor.start();
+
+ipcRenderer.on('ipcToRedux', (_, message) => {
+  if (message && message.type) {
+    store.dispatch(message);
+  }
+});
 
 render(
   <AppContainer>

--- a/app/mainWindow.js
+++ b/app/mainWindow.js
@@ -50,3 +50,7 @@ export default function showMainWindow() {
 export function getMainWindow() {
   return mainWindow;
 }
+
+export function dispatchToMainWindow(reduxAction) {
+  mainWindow.webContents.send('ipcToRedux', reduxAction);
+}

--- a/app/pages/Account/account.scss
+++ b/app/pages/Account/account.scss
@@ -63,6 +63,29 @@
 
   &__transactions {
     margin-bottom: 3rem;
+
+    &__loading {
+      @extend %row-nowrap;
+      color: rgba($black, 0.5);
+      font-weight: bold;
+      font-size: 0.8rem;
+      z-index: 100;
+      align-items: center;
+      justify-content: flex-end;
+      flex: 1 1 auto;
+
+
+      &:before {
+        content: '';
+        display: block;
+        height: 0.8rem;
+        width: 0.8rem;
+        background-size: cover;
+        background-position: center;
+        margin-right: 4px;
+        background-image: url('../../assets/images/brick-loader.svg');
+      }
+    }
   }
 
   &__domains {
@@ -70,6 +93,7 @@
   }
 
   &__panel-title {
+    @extend %row-nowrap;
     font-size: 1.2rem;
     font-weight: 500;
     margin-bottom: 1rem;

--- a/app/pages/Account/index.js
+++ b/app/pages/Account/index.js
@@ -16,6 +16,7 @@ const analytics = aClientStub(() => require('electron').ipcRenderer);
     unconfirmedBalance: state.wallet.balance.unconfirmed,
     spendableBalance: state.wallet.balance.spendable,
     height: state.node.chain.height,
+    isFetching: state.wallet.isFetching,
   }),
 )
 export default class Account extends Component {
@@ -23,6 +24,7 @@ export default class Account extends Component {
     unconfirmedBalance: PropTypes.number.isRequired,
     spendableBalance: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
+    isFetching: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -30,7 +32,7 @@ export default class Account extends Component {
   }
 
   render() {
-    const {unconfirmedBalance, spendableBalance} = this.props;
+    const {unconfirmedBalance, spendableBalance, isFetching} = this.props;
 
     return (
       <div className="account">
@@ -58,7 +60,16 @@ export default class Account extends Component {
           </div>
         </div>
         <div className="account__transactions">
-          <div className="account__panel-title">Transaction History</div>
+          <div className="account__panel-title">
+            Transaction History
+            {
+              isFetching && (
+                <div className="account__transactions__loading">
+                  Loading transactions...
+                </div>
+              )
+            }
+          </div>
           <Transactions />
         </div>
       </div>

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -68,7 +68,7 @@ class App extends Component {
 
     return (
       <div className="app">
-        <WalletSync />
+        {/*<WalletSync />*/}
         <IdleModal />
         <PassphraseModal />
         {this.renderContent()}

--- a/app/pages/Onboarding/ImportSeedFlow/index.js
+++ b/app/pages/Onboarding/ImportSeedFlow/index.js
@@ -122,8 +122,6 @@ class ImportSeedFlow extends Component {
     try {
       await walletClient.importSeed(this.state.passphrase, mnemonic);
       await this.props.completeInitialization(this.state.passphrase);
-      await this.props.startWalletSync();
-      await this.props.waitForWalletSync();
       await this.props.fetchWallet();
       await this.props.fetchTransactions();
     } catch (e) {

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -167,8 +167,6 @@ export default class Settings extends Component {
       transactions,
     } = this.props;
 
-    console.log({ transactions })
-
     return (
       <>
         {this.renderSection(

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -175,6 +175,24 @@ export default class Settings extends Component {
           'Logout',
           lockWallet,
         )}
+
+        {this.renderSection(
+          'Rescan Wallet',
+          <div>
+            <div>{`${transactions.size} transactions found in walletdb`}</div>
+          </div>,
+          'Rescan',
+          () => walletClient.rescan(0),
+        )}
+
+        {this.renderSection(
+          'API Key',
+          <span>
+                  API key for <Anchor href="https://hsd-dev.org/api-docs/#get-wallet-info">hsw-cli</Anchor> and <Anchor href="https://hsd-dev.org/api-docs/#selectwallet">hsw-rpc</Anchor>. Make sure you select the wallet id "allison".
+                </span>,
+          'View API Key',
+          () => history.push('/settings/wallet/view-api-key'),
+        )}
         {this.renderSection(
           'Delete unconfirmed transactions',
           'This will only remove pending tx from the wallet',
@@ -192,22 +210,6 @@ export default class Settings extends Component {
           'This will remove all data from Bob. Proceed with caution.',
           'Remove Wallet ',
           () => history.push('/settings/wallet/new-wallet'),
-        )}
-        {this.renderSection(
-          'API Key',
-          <span>
-                  API key for <Anchor href="https://hsd-dev.org/api-docs/#get-wallet-info">hsw-cli</Anchor> and <Anchor href="https://hsd-dev.org/api-docs/#selectwallet">hsw-rpc</Anchor>. Make sure you select the wallet id "allison".
-                </span>,
-          'View API Key',
-          () => history.push('/settings/wallet/view-api-key'),
-        )}
-        {this.renderSection(
-          'Rescan Wallet',
-          <div>
-            <div>{`${transactions.size} transactions found in walletdb`}</div>
-          </div>,
-          'Rescan',
-          () => walletClient.rescan(0),
         )}
       </>
     );

--- a/app/pages/Settings/index.js
+++ b/app/pages/Settings/index.js
@@ -22,6 +22,7 @@ import {setCustomRPCStatus} from "../../ducks/node";
 import CustomRPCConfigModal from "./CustomRPCConfigModal";
 import {fetchWalletAPIKey} from "../../ducks/walletActions";
 import Anchor from "../../components/Anchor";
+import walletClient from "../../utils/walletClient";
 
 const analytics = aClientStub(() => require('electron').ipcRenderer);
 
@@ -34,6 +35,7 @@ const analytics = aClientStub(() => require('electron').ipcRenderer);
     isRunning: state.node.isRunning,
     isChangingNodeStatus: state.node.isChangingNodeStatus,
     isTestingCustomRPC: state.node.isTestingCustomRPC,
+    transactions: state.wallet.transactions,
   }),
   dispatch => ({
     lockWallet: () => dispatch(walletActions.lockWallet()),
@@ -56,6 +58,7 @@ export default class Settings extends Component {
     stopNode: PropTypes.func.isRequired,
     startNode: PropTypes.func.isRequired,
     setCustomRPCStatus: PropTypes.func.isRequired,
+    transactions: PropTypes.object.isRequired,
   };
 
   componentDidMount() {
@@ -157,13 +160,67 @@ export default class Settings extends Component {
     )
   }
 
+  renderWallet() {
+    const {
+      history,
+      lockWallet,
+      transactions,
+    } = this.props;
+
+    console.log({ transactions })
+
+    return (
+      <>
+        {this.renderSection(
+          'Lock Wallet',
+          'Log out and lock wallet',
+          'Logout',
+          lockWallet,
+        )}
+        {this.renderSection(
+          'Delete unconfirmed transactions',
+          'This will only remove pending tx from the wallet',
+          'Zap',
+          () => history.push('/settings/wallet/zap-txs'),
+        )}
+        {this.renderSection(
+          'Reveal recovery seed phrase',
+          'This will display my unencrypted seed phrase',
+          'Reveal',
+          () => history.push('/settings/wallet/reveal-seed'),
+        )}
+        {this.renderSection(
+          'Remove wallet',
+          'This will remove all data from Bob. Proceed with caution.',
+          'Remove Wallet ',
+          () => history.push('/settings/wallet/new-wallet'),
+        )}
+        {this.renderSection(
+          'API Key',
+          <span>
+                  API key for <Anchor href="https://hsd-dev.org/api-docs/#get-wallet-info">hsw-cli</Anchor> and <Anchor href="https://hsd-dev.org/api-docs/#selectwallet">hsw-rpc</Anchor>. Make sure you select the wallet id "allison".
+                </span>,
+          'View API Key',
+          () => history.push('/settings/wallet/view-api-key'),
+        )}
+        {this.renderSection(
+          'Rescan Wallet',
+          <div>
+            <div>{`${transactions.size} transactions found in walletdb`}</div>
+          </div>,
+          'Rescan',
+          () => walletClient.rescan(0),
+        )}
+      </>
+    );
+  }
+
   renderContent() {
     const {
       isRunning,
       history,
       stopNode,
       startNode,
-      lockWallet,
       isChangingNodeStatus,
       isTestingCustomRPC,
     } = this.props;
@@ -226,40 +283,7 @@ export default class Settings extends Component {
             </>
           </Route>
           <Route path="/settings/wallet">
-            <>
-              {this.renderSection(
-                'Lock Wallet',
-                'Log out and lock wallet',
-                'Logout',
-                lockWallet,
-              )}
-              {this.renderSection(
-                'Delete unconfirmed transactions',
-                'This will only remove pending tx from the wallet',
-                'Zap',
-                () => history.push('/settings/wallet/zap-txs'),
-              )}
-              {this.renderSection(
-                'Reveal recovery seed phrase',
-                'This will display my unencrypted seed phrase',
-                'Reveal',
-                () => history.push('/settings/wallet/reveal-seed'),
-              )}
-              {this.renderSection(
-                'Remove wallet',
-                'This will remove all data from Bob. Proceed with caution.',
-                'Remove Wallet ',
-                () => history.push('/settings/wallet/new-wallet'),
-              )}
-              {this.renderSection(
-                'API Key',
-                <span>
-                  API key for <Anchor href="https://hsd-dev.org/api-docs/#get-wallet-info">hsw-cli</Anchor> and <Anchor href="https://hsd-dev.org/api-docs/#selectwallet">hsw-rpc</Anchor>. Make sure you select the wallet id "allison".
-                </span>,
-                'View API Key',
-                () => history.push('/settings/wallet/view-api-key'),
-              )}
-            </>
+            {this.renderWallet()}
           </Route>
           <Route>
             <Redirect to="/settings/general" />

--- a/app/pages/YourBids/BidStatus.js
+++ b/app/pages/YourBids/BidStatus.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import cn from 'classnames';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
@@ -17,6 +16,7 @@ class BidStatus extends Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
     address: PropTypes.string.isRequired,
+    inflateBid: PropTypes.func.isRequired,
   };
 
   isSold = () => isClosed(this.props.domain);
@@ -151,6 +151,6 @@ export default withRouter(
         domain: name,
         address: state.wallet.address,
       };
-    }
+    },
   )(BidStatus)
 );

--- a/app/pages/YourBids/index.js
+++ b/app/pages/YourBids/index.js
@@ -82,7 +82,7 @@ export default withRouter(
   connect(
     state => ({
       yourBids: state.bids.yourBids,
-    })
+    }),
   )(YourBids)
 );
 


### PR DESCRIPTION
- add a rescan button to Settings #204 
- fix parsing misclassified reveal tx #202 
- remove WalletSync modal and replace with Rescanning status in header. This allows users to still navigate in Bob when the wallet is rescanning 
![Screen Shot 2020-08-19 at 3 33 28 PM](https://user-images.githubusercontent.com/8507735/90696905-12361d80-e232-11ea-8475-2517a3ec9fdb.png)
- added a loading transaction spinner to show that transactions are loading. This should be unnecessary when pagination is implemented since load time would be much shorter.
![Screen Shot 2020-08-19 at 3 33 50 PM](https://user-images.githubusercontent.com/8507735/90696875-ffbbe400-e231-11ea-80bb-a3b6e6e0a155.png)

