### PR TITLE
wallet: refresh balance on new block and on mount

### DIFF
--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -9,7 +9,14 @@ import rimraf from 'rimraf';
 import { ConnectionTypes, getConnection } from '../connections/service';
 import crypto from 'crypto';
 import { dispatchToMainWindow } from '../../mainWindow';
-import {SET_WALLETS, START_SYNC_WALLET, STOP_SYNC_WALLET, SYNC_WALLET_PROGRESS} from '../../ducks/walletReducer';
+import {
+  getInitialState,
+  NONE, SET_BALANCE,
+  SET_WALLETS,
+  START_SYNC_WALLET,
+  STOP_SYNC_WALLET,
+  SYNC_WALLET_PROGRESS
+} from '../../ducks/walletReducer';
 import {SET_FEE_INFO, SET_NODE_INFO} from "../../ducks/nodeReducer";
 
 const WalletNode = require('hsd/lib/wallet/node');
@@ -592,6 +599,7 @@ class WalletService {
     this.node = node;
     this.client = new WalletClient(walletOptions);
     await this.refreshNodeInfo();
+    await this.refreshWalletInfo();
   };
 
   _onNodeStop = async () => {
@@ -604,6 +612,17 @@ class WalletService {
     this.node = null;
     this.client = null;
     this.didSelectWallet = false;
+  };
+
+  refreshWalletInfo = async () => {
+    if (!this.name) return;
+    const accountInfo = await this.getAccountInfo();
+    const apiKey = await this.getAPIKey();
+
+    dispatchToMainWindow({
+      type: SET_BALANCE,
+      payload: accountInfo.balance,
+    });
   };
 
   refreshNodeInfo = async () => {
@@ -628,6 +647,7 @@ class WalletService {
   onNewBlock = async (entry, txs) => {
     await this._ensureClient();
     await this.refreshNodeInfo();
+    await this.refreshWalletInfo();
 
     if (entry && txs) {
       await this.node.wdb.addBlock(entry, txs);
@@ -657,6 +677,7 @@ class WalletService {
           type: SYNC_WALLET_PROGRESS,
           payload: walletHeight,
         });
+        await this.refreshWalletInfo();
         return;
       }
 
@@ -669,6 +690,7 @@ class WalletService {
           type: SYNC_WALLET_PROGRESS,
           payload: walletHeight,
         });
+        await this.refreshWalletInfo();
         this.lastProgressUpdate = now;
       }
     } catch (e) {

--- a/app/ducks/walletReducer.js
+++ b/app/ducks/walletReducer.js
@@ -4,6 +4,7 @@ export const IMPORTED = 'IMPORTED';
 export const ELECTRON = 'ELECTRON';
 
 export const SET_WALLET = 'app/wallet/setWallet';
+export const SET_BALANCE = 'app/wallet/setBalance';
 export const UNLOCK_WALLET = 'app/wallet/unlockWallet';
 export const LOCK_WALLET = 'app/wallet/lockWallet';
 export const SET_TRANSACTIONS = 'app/wallet/setTransactions';
@@ -62,8 +63,20 @@ export default function walletReducer(state = getInitialState(), {type, payload}
           lockedConfirmed: payload.balance.lockedConfirmed,
           spendable: payload.balance.unconfirmed - payload.balance.lockedUnconfirmed,
         },
-        initialized: payload.initialized,
+        initialized: typeof payload.initialized === 'undefined' ? state.initialized : payload.initialized,
         apiKey: payload.apiKey,
+      };
+    case SET_BALANCE:
+      return {
+        ...state,
+        balance: {
+          ...state.balance,
+          confirmed: payload.confirmed,
+          unconfirmed: payload.unconfirmed,
+          lockedUnconfirmed: payload.lockedUnconfirmed,
+          lockedConfirmed: payload.lockedConfirmed,
+          spendable: payload.unconfirmed - payload.lockedUnconfirmed,
+        }
       };
     case SET_API_KEY:
       return {

--- a/app/pages/Account/index.js
+++ b/app/pages/Account/index.js
@@ -6,6 +6,7 @@ import './account.scss';
 import { displayBalance } from '../../utils/balances';
 import Tooltipable from '../../components/Tooltipable';
 import { clientStub as aClientStub } from '../../background/analytics/client';
+import * as walletActions from "../../ducks/walletActions";
 
 const pkg = require('../../../package.json');
 
@@ -18,6 +19,9 @@ const analytics = aClientStub(() => require('electron').ipcRenderer);
     height: state.node.chain.height,
     isFetching: state.wallet.isFetching,
   }),
+  dispatch => ({
+    fetchWallet: () => dispatch(walletActions.fetchWallet()),
+  }),
 )
 export default class Account extends Component {
   static propTypes = {
@@ -25,10 +29,12 @@ export default class Account extends Component {
     spendableBalance: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
     isFetching: PropTypes.bool.isRequired,
+    fetchWallet: PropTypes.func.isRequired,
   };
 
   componentDidMount() {
     analytics.screenView('Account');
+    this.props.fetchWallet();
   }
 
   render() {


### PR DESCRIPTION
closes #250 

this will refresh wallet balance when:
1. `Account` component is mounted
2. a new block is received
3. wallet rescan progress is updated 