### PR TITLE
Swaps: fix input validation, transfer address, wallet unlock before sign

### DIFF
--- a/app/ducks/names.js
+++ b/app/ducks/names.js
@@ -1,3 +1,4 @@
+import { Address } from 'hsd/lib/primitives';
 import nodeClient from '../utils/nodeClient';
 import walletClient from '../utils/walletClient';
 import * as namesDb from '../db/names';
@@ -120,7 +121,15 @@ export const getNameInfo = name => async (dispatch) => {
     if (res) {
       const {tx: buyTx} = res;
       const buyOutput = buyTx.outputs[info.owner.index];
-      isOwner = !!await walletClient.getCoin(info.owner.hash, info.owner.index);
+      const coin = await walletClient.getCoin(info.owner.hash, info.owner.index); 
+      isOwner = !!coin;
+      if (coin && coin.covenant.action === 'TRANSFER') {
+        const {network} = await nodeClient.getInfo();
+        info.transferTo = Address.fromHash(
+          Buffer.from(coin.covenant.items[3], 'hex'),
+          Number(coin.covenant.items[2])
+        ).toString(network);
+      }
 
       winner = {
         address: buyOutput.address,

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -293,6 +293,13 @@ export const closeGetPassphrase = () => ({
   payload: {get: false},
 });
 
+export const waitForPassphrase = () => async (dispatch) => {
+  await new Promise((resolve, reject) => {
+    dispatch(getPassphrase(resolve, reject));
+  });
+  return null;
+};
+
 export const watchActivity = () => dispatch => {
   if (!idleInterval) {
     // Increment idle once a minute

--- a/app/pages/DomainManager/ClaimNameForPayment.js
+++ b/app/pages/DomainManager/ClaimNameForPayment.js
@@ -1,3 +1,4 @@
+import { Amount } from 'hsd/lib/ui';
 import React, { Component } from 'react';
 import { MiniModal } from '../../components/Modal/MiniModal';
 import { MTX } from 'hsd/lib/primitives';
@@ -142,7 +143,7 @@ export default class ClaimNameForPayment extends Component {
           <dt>Address Receiving Funds</dt>
           <dd>{this.state.fundingAddr}</dd>
           <dt>Price</dt>
-          <dd>{Math.floor(this.state.price / 1e6)} HNS</dd>
+          <dd>{Amount.fromValue(this.state.price).toCoins()} HNS</dd>
         </dl>
 
         <div className="claim-name-for-payment__verification-buttons">

--- a/app/pages/DomainManager/ClaimNameForPayment.js
+++ b/app/pages/DomainManager/ClaimNameForPayment.js
@@ -5,6 +5,7 @@ import { MTX } from 'hsd/lib/primitives';
 import { connect } from 'react-redux';
 import { showSuccess } from '../../ducks/notifications';
 import { claimPaidTransfer } from '../../ducks/names';
+import { waitForPassphrase } from '../../ducks/walletActions';
 
 @connect(
   (state) => ({
@@ -13,6 +14,7 @@ import { claimPaidTransfer } from '../../ducks/names';
   (dispatch) => ({
     showSuccess: (message) => dispatch(showSuccess(message)),
     claimPaidTransfer: (hex) => dispatch(claimPaidTransfer(hex)),
+    waitForPassphrase: () => dispatch(waitForPassphrase()),
   }),
 )
 export default class ClaimNameForPayment extends Component {
@@ -54,6 +56,7 @@ export default class ClaimNameForPayment extends Component {
       this.setState({
         isLoading: true,
       });
+      await this.props.waitForPassphrase();
       await this.props.claimPaidTransfer(this.state.hex);
       this.props.onClose();
       this.props.showSuccess('Successfully claimed paid transfer. Please wait 1 block for the name to appear.');

--- a/app/pages/MyDomain/FinalizeWithPaymentModal.js
+++ b/app/pages/MyDomain/FinalizeWithPaymentModal.js
@@ -12,7 +12,6 @@ export class FinalizeWithPaymentModal extends Component {
 
     this.state = {
       error: '',
-      recipient: '',
       price: '',
       hex: '',
     };
@@ -24,7 +23,7 @@ export class FinalizeWithPaymentModal extends Component {
       const hex = await this.props.finalizeWithPayment(
         this.props.name,
         fundingAddr,
-        this.state.recipient,
+        this.props.transferTo,
         Number(this.state.price),
       );
       this.setState({
@@ -75,15 +74,16 @@ export class FinalizeWithPaymentModal extends Component {
   }
 
   renderForm() {
-    const isValid = !!this.state.recipient && !!this.state.price && (
+    const isValid = !!this.state.price && (
       !!this.state.price && Number(this.state.price) <= 2000
     );
 
     return (
       <>
         <p>
-          To require payment to finalize this transfer, please
-          fill out the steps below.
+          To require payment to finalize this transfer,
+          verify the recipient's name transfer address and
+          enter the agreed price in HNS below.
         </p>
 
         <p>
@@ -96,18 +96,6 @@ export class FinalizeWithPaymentModal extends Component {
         <div className="send__to">
           <div className="send__input">
             <input
-              type="text"
-              value={this.state.recipient}
-              onChange={(e) => this.setState({
-                recipient: e.target.value,
-              })}
-              placeholder="Enter a recipient for the name..."
-            />
-          </div>
-        </div>
-        <div className="send__to">
-          <div className="send__input">
-            <input
               type="number"
               min={0}
               placeholder="0.000000"
@@ -117,6 +105,12 @@ export class FinalizeWithPaymentModal extends Component {
               value={this.state.price}
             />
           </div>
+        </div>
+        <div className="send__to">      
+          Name recipient address:
+        </div>
+        <div className="send__to">
+          {this.props.transferTo}
         </div>
         <div className="send__actions">
           <button

--- a/app/pages/MyDomain/FinalizeWithPaymentModal.js
+++ b/app/pages/MyDomain/FinalizeWithPaymentModal.js
@@ -1,3 +1,5 @@
+import { Amount } from 'hsd/lib/ui';
+import {consensus} from 'hsd/lib/protocol';
 import React, { Component } from 'react';
 import { MiniModal } from '../../components/Modal/MiniModal';
 import { clientStub as wClientStub } from '../../background/wallet/client';
@@ -24,7 +26,7 @@ export class FinalizeWithPaymentModal extends Component {
         this.props.name,
         fundingAddr,
         this.props.transferTo,
-        Number(this.state.price),
+        Amount.fromCoins(this.state.price).toValue(),
       );
       this.setState({
         hex,
@@ -73,6 +75,15 @@ export class FinalizeWithPaymentModal extends Component {
     );
   }
 
+  processValue = (val) => {
+    const value = val.match(/[0-9]*\.?[0-9]{0,6}/g)[0];
+    if (Number.isNaN(parseFloat(value)))
+      return;
+    if (value * consensus.COIN > consensus.MAX_MONEY)
+      return;
+    this.setState({price: value});
+  }
+
   renderForm() {
     const isValid = !!this.state.price && (
       !!this.state.price && Number(this.state.price) <= 2000
@@ -99,9 +110,7 @@ export class FinalizeWithPaymentModal extends Component {
               type="number"
               min={0}
               placeholder="0.000000"
-              onChange={(e) => this.setState({
-                price: e.target.value,
-              })}
+              onChange={(e) => this.processValue(e.target.value)}
               value={this.state.price}
             />
           </div>

--- a/app/pages/MyDomain/FinalizeWithPaymentModal.js
+++ b/app/pages/MyDomain/FinalizeWithPaymentModal.js
@@ -5,6 +5,7 @@ import { MiniModal } from '../../components/Modal/MiniModal';
 import { clientStub as wClientStub } from '../../background/wallet/client';
 import { finalizeWithPayment } from '../../ducks/names';
 import { connect } from 'react-redux';
+import { waitForPassphrase } from '../../ducks/walletActions';
 
 const wallet = wClientStub(() => require('electron').ipcRenderer);
 
@@ -22,6 +23,7 @@ export class FinalizeWithPaymentModal extends Component {
   onClickFinalize = async () => {
     try {
       const fundingAddr = (await wallet.generateReceivingAddress()).address;
+      await this.props.waitForPassphrase();
       const hex = await this.props.finalizeWithPayment(
         this.props.name,
         fundingAddr,
@@ -139,5 +141,6 @@ export default connect(
   () => ({}),
   (dispatch) => ({
     finalizeWithPayment: (name, fundingAddr, recipient, price) => dispatch(finalizeWithPayment(name, fundingAddr, recipient, price)),
+    waitForPassphrase: () => dispatch(waitForPassphrase()),
   }),
 )(FinalizeWithPaymentModal);

--- a/app/pages/MyDomain/TransferDetails.js
+++ b/app/pages/MyDomain/TransferDetails.js
@@ -135,6 +135,7 @@ class TransferDetails extends Component {
                   isShowingFinalizeWithPayment: false,
                 })}
                 name={this.props.name}
+                transferTo={info.transferTo}
               />
             )}
             {this.renderRevoke()}


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/224

This is a cherry-pick of my forked version: https://github.com/pinheadmz/bob-wallet/commit/46587640e9023ca61b2c200fb1abb0940fcb2ce2

Rebased and conflict-resolved on to kyokan/bob-wallet master, and split into three commits for easier review.

I tested out the patch on my own fork (and plan to post a video soon explaining the feature!) but did not yet test this PR as I applied it here to master. I've had issues testing Bob locally (but its been a while since I tried so might be all good now, just need time to try it out) but especially running two Bob nodes at once is hard (this is the primary reason I'm maintaining my own fork). So these changes should be tested locally by a project maintainer before merging if possible.

I also don't *think* the issues in #224 were addressed yet, I checked but didn't see anything. Especially important to check is the units for the swap (HNS vs dollarydoos) if you already fixed that somewhere in the lower levels, this PR will need to be rebased again.

And finally - the `processValue()` is now implemented in a few places (`RepairBid`, `BidNow`, and now `FinalizeWithPaymentModal`) so that can probably be cleaned up and moved to a util file somewhere.


ping @mslipper 
