### PR TITLE
auction: close bidding 1 block early

### DIFF
--- a/app/components/AuctionGraph/index.js
+++ b/app/components/AuctionGraph/index.js
@@ -142,7 +142,7 @@ export default class AuctionGraph extends Component {
           <div className="auction-graph__column__headline">Reveal Period</div>
           <ProgressBar percentage={revealProgress}/>
           <div className="auction-graph__column__text__row">
-            { this.maybeRenderDateBlock(() => isBidding(domain), stats.bidPeriodEnd, stats.hoursUntilReveal) || this.maybeRenderDateBlock(() => isReveal(domain), stats.revealPeriodStart, stats.hoursUntilClose) || this.renderPlaceholder(REVEALING < currentStep)}
+            { this.maybeRenderDateBlock(() => isBidding(domain), stats.bidPeriodEnd, stats.hoursUntilReveal) || this.maybeRenderDateBlock(() => isReveal(domain), stats.revealPeriodStart || stats.bidPeriodEnd, stats.hoursUntilClose) || this.renderPlaceholder(REVEALING < currentStep)}
             { this.maybeRenderDateBlock(() => isReveal(domain), stats.revealPeriodEnd, stats.hoursUntilClose, true) || this.renderPlaceholder(REVEALING < currentStep, true)}
           </div>
         </div>

--- a/app/components/AuctionGraph/index.js
+++ b/app/components/AuctionGraph/index.js
@@ -53,7 +53,7 @@ export default class AuctionGraph extends Component {
       this.setState({ 
         currentStep: ISBIDDING, 
         openProgress: 100,
-        biddingProgress: (1 - (stats.bidPeriodEnd - this.props.chain.height) / (stats.bidPeriodEnd - stats.bidPeriodStart)) * 100,
+        biddingProgress: (1 - (stats.bidPeriodEnd - 1 - this.props.chain.height) / (stats.bidPeriodEnd - 1 - stats.bidPeriodStart)) * 100,
       }); 
     } else if (isReveal(domain)) {
       this.setState({ 

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {consensus} from 'hsd/lib/protocol';
+import Network from 'hsd/lib/protocol/network'
 import {
   AuctionPanel,
   AuctionPanelFooter,
@@ -35,6 +36,7 @@ class BidNow extends Component {
     waitForWalletSync: PropTypes.func.isRequired,
     startWalletSync: PropTypes.func.isRequired,
     stopWalletSync: PropTypes.func.isRequired,
+    network: PropTypes.string.isRequired,
   };
 
   state = {
@@ -53,15 +55,18 @@ class BidNow extends Component {
     const {stats} = info || {};
     const {hoursUntilReveal} = stats || {};
 
-    if (hoursUntilReveal < 24) {
-      const hours = Math.floor(hoursUntilReveal % 24);
-      const mins = Math.floor((hoursUntilReveal % 1) * 60);
+    const network = Network.get(this.props.network || 'main');
+    const timeLeftToBid = hoursUntilReveal - (network.pow.targetSpacing / 60 / 60) // seconds to hours
+
+    if (timeLeftToBid < 24) {
+      const hours = Math.floor(timeLeftToBid % 24);
+      const mins = Math.floor((timeLeftToBid % 1) * 60);
       return `~${hours}h ${mins}m`;
     }
 
-    const days = Math.floor(hoursUntilReveal / 24);
-    const hours = Math.floor(hoursUntilReveal % 24);
-    const mins = Math.floor((hoursUntilReveal % 1) * 60);
+    const days = Math.floor(timeLeftToBid / 24);
+    const hours = Math.floor(timeLeftToBid % 24);
+    const mins = Math.floor((timeLeftToBid % 1) * 60);
     return `~${days}d ${hours}h ${mins}m`;
   };
 
@@ -141,7 +146,7 @@ class BidNow extends Component {
           )
         }
         <AuctionPanelHeader title="Auction Details">
-          <AuctionPanelHeaderRow label="Reveal Ends:">
+          <AuctionPanelHeaderRow label="Bidding Ends:">
             <div className="domains__bid-now__info__time-remaining">
               <div>
                 {this.getTimeRemaining()}

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -181,7 +181,7 @@ export default class Auction extends Component {
     if (isAvailable(domain) || isOpening(domain) || isBidding(domain) || isReveal(domain)) {
       return (
         <React.Fragment>
-          <Collapsible className="domains__content__info-panel" title="Your Bids" pillContent={pillContent}>
+          <Collapsible className="domains__content__info-panel" title="Bids" pillContent={pillContent}>
             {this.props.domain ?
               <BidHistory
                 bids={this.props.domain.bids}

--- a/app/utils/nameHelpers.js
+++ b/app/utils/nameHelpers.js
@@ -74,6 +74,13 @@ function checkState(name, expectedState) {
     return false;
   }
 
+  // This check is needed for #278:
+  // When the current height is 1 less than bidPeriodEnd,
+  // no new bids can be added as the last bid block is already being mined.
+  if (info.stats.blocksUntilReveal === 1) {
+    if (expectedState == 'BIDDING') return false;
+    if (expectedState == 'REVEAL') return true;
+  }
   return info.state === expectedState;
 }
 


### PR DESCRIPTION
This fixes #278.

The changes made checks if `blocksUntilReveal` is exactly 1 and overrides `isBidding()` and `isReveal()`, effectively closing the bidding (and hiding the Bid button) early.
The Bidding Ends time is also reduced by 1 block.

This PR also fixes:
- Label on the right (when bidding) from **Reveal Ends** to **Bidding Ends**
- **Your Bids** to **Bids** as all bids are shown

## Example
`y/` and `z/` are opened 1 block apart at heights 109 and 110.

At height 119:
```
y/:
bidPeriodStart: 115
bidPeriodEnd: 120
blocksUntilReveal: 1

z/:
bidPeriodStart: 116
bidPeriodEnd: 121
blocksUntilReveal: 2
```
![image](https://user-images.githubusercontent.com/5113343/104614789-9344f400-56ae-11eb-9d0a-613c8a5e2fed.png)
![image](https://user-images.githubusercontent.com/5113343/104618034-38150080-56b2-11eb-9e36-21163abc4970.png)
