### PR TITLE
ui: display long names properly

### DIFF
--- a/app/components/Table/index.scss
+++ b/app/components/Table/index.scss
@@ -33,7 +33,7 @@
 
   &__row {
     @extend %row-nowrap;
-    height: 2.8rem;
+    min-height: 2.8rem;
     align-items: center;
     border: 1px solid darken($athens-gray, 5);
     border-top: none;
@@ -44,6 +44,9 @@
       font-size: .8rem;
       font-weight: 400;
       padding-left: 1rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     &__item:nth-of-type(1) {

--- a/app/components/Transactions/index.scss
+++ b/app/components/Transactions/index.scss
@@ -9,6 +9,9 @@
   &__tld-link {
     cursor: pointer;
     border-bottom: 1px dashed lighten($manatee-gray, 25);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &:hover {
       color: lighten($manatee-gray, 10);
@@ -65,6 +68,7 @@
 
   &__tx-value {
     flex: 0 0 auto;
+    margin-left: 1rem;
   }
 
   &__title {
@@ -73,6 +77,7 @@
     font-weight: 500;
     margin-bottom: 0.1rem;
     cursor: pointer;
+    flex-shrink: 0;
 
     &--pending {
       color: rgba($black, 0.5);
@@ -82,6 +87,7 @@
   &__party {
     margin-left: 1rem;
     color: $manatee-gray;
+    overflow: hidden;
   }
 
   &__subtitle {

--- a/app/pages/Auction/domains.scss
+++ b/app/pages/Auction/domains.scss
@@ -12,6 +12,7 @@
     &__title {
       font-weight: 500;
       font-size: 2.5rem;
+      overflow-wrap: break-word;
     }
 
     &__loading-wrapper {

--- a/app/pages/DomainManager/domain-manager.scss
+++ b/app/pages/DomainManager/domain-manager.scss
@@ -54,6 +54,7 @@
       &__header {
         &__item:nth-of-type(1) {
           flex: 0 0 12rem;
+          flex-grow: 1;
         }
 
         &__item:nth-of-type(3) {
@@ -81,6 +82,7 @@
 
         &__item:nth-of-type(1) {
           flex: 0 0 12rem;
+          flex-grow: 1;
         }
 
         &__item:nth-of-type(3) {


### PR DESCRIPTION
Fixes #195.

Long names are truncated with ellipses everywhere except the Auction page, where the whole name is shown broken into multiple lines (as suggested in the issue).
Will change/update if there are any better suggestions.

Old pics are in the issue, after pics below.

![image](https://user-images.githubusercontent.com/5113343/104636533-808be880-56c9-11eb-932a-e434648a0024.png)
![image](https://user-images.githubusercontent.com/5113343/104636551-871a6000-56c9-11eb-87fc-9fdf0bbecff5.png)
![image](https://user-images.githubusercontent.com/5113343/104636573-8f729b00-56c9-11eb-8e3a-f477e2ca7763.png)
![image](https://user-images.githubusercontent.com/5113343/104636599-9b5e5d00-56c9-11eb-923b-39e669f0ee7e.png)
![image](https://user-images.githubusercontent.com/5113343/104636624-a618f200-56c9-11eb-8b67-ec06b5d7b1f8.png)

