### PR TITLE
my-domain: only show possible actions

### DIFF
--- a/app/pages/Auction/BidActionPanel/Owned.js
+++ b/app/pages/Auction/BidActionPanel/Owned.js
@@ -19,6 +19,7 @@ class Owned extends Component {
     chain: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     sendRenewal: PropTypes.func.isRequired,
+    sendRegister: PropTypes.func.isRequired,
     showSuccess: PropTypes.func.isRequired,
     showError: PropTypes.func.isRequired,
     history: PropTypes.shape({
@@ -32,12 +33,19 @@ class Owned extends Component {
       .catch(e => this.props.showError(e.message))
   };
 
+  sendRegister = () => {
+    this.props.sendRegister()
+      .then(() => this.props.showSuccess('Your register request is submitted! Please wait around 15 minutes for it to be confirmed.'))
+      .catch(e => this.props.showError(e.message))
+  };
+
   render() {
     const { domain, history, name, chain } = this.props;
     const { info, bids = [] } = domain || {};
     const { highest, stats } = info || {};
     const { renewalPeriodStart, renewalPeriodEnd } = stats || {};
-    const isPending = domain.pendingOperation === 'RENEW';
+    const isPendingRenew = domain.pendingOperation === 'RENEW';
+    const isPendingRegister = domain.pendingOperation === 'REGISTER';
 
     return (
       <AuctionPanel>
@@ -56,13 +64,23 @@ class Owned extends Component {
           </AuctionPanelHeaderRow>
         </AuctionPanelHeader>
         <AuctionPanelFooter className="domains__action-panel__owned-actions">
-          <button
-            className="domains__action-panel__renew-domain-btn"
-            onClick={this.sendRenewal}
-            disabled={isPending || !chain || chain.height < renewalPeriodStart}
-          >
-            { isPending ? 'Renewing': 'Renew my domain' }
-          </button>
+          { info.registered ? 
+            <button
+              className="domains__action-panel__renew-domain-btn"
+              onClick={this.sendRenewal}
+              disabled={isPendingRenew || !chain || chain.height < renewalPeriodStart}
+            >
+              { isPendingRenew ? 'Renewing': 'Renew my domain' }
+            </button>
+            :
+            <button
+              className="domains__action-panel__renew-domain-btn"
+              onClick={this.sendRegister}
+              disabled={isPendingRegister}
+            >
+              { isPendingRegister ? 'Registering': 'Register my domain' }
+            </button>
+          }
           <button
             className="domains__action-panel__manage-domain-btn"
             onClick={() => history.push(`/domain_manager/${name}`)}
@@ -82,6 +100,7 @@ export default withRouter(
     }),
     (dispatch, { name }) => ({
       sendRenewal: () => dispatch(names.sendRenewal(name)),
+      sendRegister: () => dispatch(names.sendRegister(name)),
       showSuccess: (message) => dispatch(showSuccess(message)),
       showError: (message) => dispatch(showError(message)),
     })

--- a/app/pages/MyDomain/TransferDetails.js
+++ b/app/pages/MyDomain/TransferDetails.js
@@ -99,6 +99,16 @@ class TransferDetails extends Component {
       );
     }
 
+    if (!info.registered) {
+      return (
+        <div className="transfer-details">
+          <p>
+            This domain can only be transferred after it is registered.
+          </p>
+        </div>
+      );
+    }
+
     if (domain.pendingOperation === 'TRANSFER') {
       return (
         <div className="transfer-details">

--- a/app/pages/MyDomain/index.js
+++ b/app/pages/MyDomain/index.js
@@ -39,6 +39,15 @@ class MyDomain extends Component {
     analytics.screenView('My Domains');
   }
 
+  handleRegister = () => {
+    this.props.sendRegister(this.props.name)
+      .then(() => {
+        this.props.showSuccess('Your register request is submitted! Please wait around 15 minutes for it to be confirmed.');
+        analytics.track('registered domain');
+      })
+      .catch(e => this.props.showError(e.message));
+  };
+
   handleRenew = () => {
     this.props.sendRenewal(this.props.name)
       .then(() => {
@@ -48,7 +57,7 @@ class MyDomain extends Component {
       .catch(e => this.props.showError(e.message));
   };
 
-  renderRenewal() {
+  renderRegisterOrRenewal() {
     const {chain} = this.props;
     const domain = this.props.domain || {};
     const info = domain.info || {};
@@ -62,24 +71,48 @@ class MyDomain extends Component {
       return;
     }
 
-    if (domain.pendingOperation === 'RENEW') {
+    // If registered, show renew
+    if (info.registered) {
+      if (domain.pendingOperation === 'RENEW') {
+        return (
+          <div
+            className="my-domain__header__renewing-link"
+          >
+            Renewing...
+          </div>
+        );
+      }
+
       return (
         <div
-          className="my-domain__header__renewing-link"
+          className="my-domain__header__reveal-link"
+          onClick={this.handleRenew}
         >
-          Renewing...
+          Send Renewal
+        </div>
+      );
+
+    // Else, show register
+    } else {
+      if (domain.pendingOperation === 'REGISTER') {
+        return (
+          <div
+            className="my-domain__header__renewing-link"
+          >
+            Registering...
+          </div>
+        );
+      }
+
+      return (
+        <div
+          className="my-domain__header__reveal-link"
+          onClick={this.handleRegister}
+        >
+          Send Register
         </div>
       );
     }
-
-    return (
-      <div
-        className="my-domain__header__reveal-link"
-        onClick={this.handleRenew}
-      >
-        Send Renewal
-      </div>
-    );
   }
 
   render() {
@@ -98,7 +131,7 @@ class MyDomain extends Component {
           <div className="my-domain__header__expires-text">
             {this.renderExpireText()}
           </div>
-          {this.renderRenewal()}
+          {this.renderRegisterOrRenewal()}
         </div>
         <Collapsible className="my-domain__info-panel" title="Domain Details" defaultCollapsed>
           <DomainDetails name={name} />
@@ -109,7 +142,7 @@ class MyDomain extends Component {
             transferring={!!domain.info && domain.info.transfer !== 0}
           />
         </Collapsible>
-        <Collapsible className="my-domain__info-panel" title="Your Bids" defaultCollapsed>
+        <Collapsible className="my-domain__info-panel" title="Bids" defaultCollapsed>
           {
             this.props.domain
               ? (
@@ -151,6 +184,7 @@ export default withRouter(
     (dispatch, ownProps) => ({
       getNameInfo: () => dispatch(names.getNameInfo(ownProps.match.params.name)),
       sendRenewal: tld => dispatch(names.sendRenewal(tld)),
+      sendRegister: tld => dispatch(names.sendRegister(tld)),
       showSuccess: (message) => dispatch(showSuccess(message)),
       showError: (message) => dispatch(showError(message)),
       fetchPendingTransactions: () => dispatch(fetchPendingTransactions()),


### PR DESCRIPTION
Closes #185, Closes #147.

This PR:
- Shows **Send Register** instead of **Send Renewal** in My Domain when the name is not registered
- Does not allow transfer when the name is not registered
- Change label **Your Bids** to **Bids** in My Domain as all bids are shown
- Show **Register my domain** instead of **Renew my domain** on Auctions page when the name is not registered

![image](https://user-images.githubusercontent.com/5113343/104683296-a4c4e500-571c-11eb-8b70-7c0e32306615.png)
![image](https://user-images.githubusercontent.com/5113343/104683339-b9a17880-571c-11eb-8877-07bfd1242ab3.png)
