### PR TITLE
Auctions UI fixes

### DIFF
--- a/app/components/AuctionGraph/index.js
+++ b/app/components/AuctionGraph/index.js
@@ -41,6 +41,12 @@ export default class AuctionGraph extends Component {
     await this.getStatusInfo(this.props.domain);
   }
 
+  async componentDidUpdate(prevProps, prevState) {
+    if (this.props.chain.height !== prevProps.chain.height) {
+      await this.getStatusInfo(this.props.domain);
+    }
+  }
+
   getStatusInfo(domain) {
     const stats = domain.info && domain.info.stats || {};
 

--- a/app/components/Collapsible/collapsible.scss
+++ b/app/components/Collapsible/collapsible.scss
@@ -36,7 +36,8 @@
     opacity: 1;
     // padding: 1rem;
     position: relative;
-    max-height: 50rem;
+    max-height: 35rem;
+    overflow-y: auto;
     height: auto;
     transition: 0.5s ease-out;
 

--- a/app/pages/Auction/BidActionPanel/BidNow.js
+++ b/app/pages/Auction/BidActionPanel/BidNow.js
@@ -156,7 +156,7 @@ class BidNow extends Component {
           <AuctionPanelHeaderRow label="Total Bids:">
             {bids.length}
           </AuctionPanelHeaderRow>
-          <AuctionPanelHeaderRow label="Highest Mask:">
+          <AuctionPanelHeaderRow label="Highest Lockup:">
             {highest}
           </AuctionPanelHeaderRow>
           <div className="domains__bid-now__info__disclaimer">
@@ -229,12 +229,12 @@ class BidNow extends Component {
               className="domains__bid-now__mask"
               tooltipContent={(
                 <span className="domains__bid-now__mask-tooltip">
-                  <span>You can disguise your bid amount to cover up your actual bid. Disguise gets added on top of your bid amount, resulting in your mask. The entire mask amount will be frozen during the bidding period. </span>
-                  <span>The disguise amount will be returned after the reveal period, regardless of outcome.</span>
+                  <span>You can add a blind to your bid amount to cover up your actual bid. Your bid + blind is called lockup, which is the only value that other bidders see. The entire lockup will be frozen during the bidding period.</span>
+                  <span>The blind will be returned when it is revealed during the reveal period, whether you win the auction or not.</span>
                 </span>
               )}
             >
-              Disguise
+              Blind
             </Tooltipable>
             <span> Amount:</span>
           </div>
@@ -254,7 +254,7 @@ class BidNow extends Component {
         className="domains__bid-now__form__link"
         onClick={() => this.setState({shouldAddDisguise: true})}
       >
-        Add Disguise
+        Add a blind
       </div>
     );
   }
@@ -270,7 +270,7 @@ class BidNow extends Component {
             <AuctionPanelHeaderRow label="Total Bids:">
               {totalBids < 0 ? '?' : displayBalance(totalBids, true)}
             </AuctionPanelHeaderRow>
-            <AuctionPanelHeaderRow label="Total Masks:">
+            <AuctionPanelHeaderRow label="Total Lockups:">
               {displayBalance(totalMasks, true)}
             </AuctionPanelHeaderRow>
           </div>
@@ -319,7 +319,7 @@ class BidNow extends Component {
                 />
               </div>
             </AuctionPanelHeaderRow>
-            <AuctionPanelHeaderRow label="Disguise Amount:">
+            <AuctionPanelHeaderRow label="Blind Amount:">
               <div className="domains__bid-now__review-info">
                 <div className="domains__bid-now__info__value">
                   {disguiseAmount ? `${disguiseAmount} HNS` : ' - '}
@@ -335,7 +335,7 @@ class BidNow extends Component {
             </AuctionPanelHeaderRow>
             <div className="domains__bid-now__divider" />
             <AuctionPanelHeaderRow
-              label="Total Mask:"
+              label="Total Lockup:"
               className="domains__bid-now__review-total"
             >
               <div className="domains__bid-now__info__value">

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -172,7 +172,10 @@ class Reveal extends Component {
     return (
       <div className="domains__bid-now__info__warning">
         You will lose {displayBalance(totalMasks, true)} if you don't reveal before{' '}
-        <Blocktime height={this.props.domain.info.stats.revealPeriodEnd} format="ll" />
+        {this.props.domain.info.stats.revealPeriodEnd ?
+          <Blocktime height={this.props.domain.info.stats.revealPeriodEnd} format="ll" />
+          : 'the Reveal Period ends!'
+        }
       </div>
     );
   }

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -116,7 +116,7 @@ class Reveal extends Component {
           <AuctionPanelHeaderRow label="Total Bids:">
             {totalBids < 0 ? '?' : displayBalance(totalBids, true)}
           </AuctionPanelHeaderRow>
-          <AuctionPanelHeaderRow label="Total Masks:">
+          <AuctionPanelHeaderRow label="Total Lockups:">
             {displayBalance(totalMasks, true)}
           </AuctionPanelHeaderRow>
           {this.renderWarning()}

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -32,21 +32,21 @@ class Reveal extends Component {
   getTimeRemaining = () => {
     const {info} = this.props.domain || {};
     const {stats} = info || {};
-    const {revealPeriodEnd} = stats || {};
+    const {revealPeriodEnd, hoursUntilClose} = stats || {};
 
     if (!revealPeriodEnd) {
       return 'Revealing now!';
     }
 
-    if (revealPeriodEnd < 24) {
-      const hours = Math.floor(revealPeriodEnd % 24);
-      const mins = Math.floor((revealPeriodEnd % 1) * 60);
+    if (hoursUntilClose < 24) {
+      const hours = Math.floor(hoursUntilClose);
+      const mins = Math.floor((hoursUntilClose - hours) * 60);
       return `~${hours}h ${mins}m`;
     }
 
-    const days = Math.floor(revealPeriodEnd / 24);
-    const hours = Math.floor(revealPeriodEnd % 24);
-    const mins = Math.floor((revealPeriodEnd % 1) * 60);
+    const days = Math.floor(hoursUntilClose / 24);
+    const hours = Math.floor(hoursUntilClose - days*24);
+    const mins = Math.floor((hoursUntilClose - days*24 - hours) * 60);
     return `~${days}d ${hours}h ${mins}m`;
   };
 

--- a/app/pages/Auction/BidActionPanel/Reveal.js
+++ b/app/pages/Auction/BidActionPanel/Reveal.js
@@ -67,7 +67,7 @@ class Reveal extends Component {
   render() {
     const {domain, hasRevealableBid} = this.props;
     const {bids = [], info} = domain || {};
-    const {highest = 0} = info || {};
+    const highest = Math.max(bids.map(bid => bid.value));
 
     return (
       <AuctionPanel>
@@ -82,8 +82,8 @@ class Reveal extends Component {
           <AuctionPanelHeaderRow label="Total Bids:">
             {bids.length}
           </AuctionPanelHeaderRow>
-          <AuctionPanelHeaderRow label="Highest Mask:">
-            {highest}
+          <AuctionPanelHeaderRow label="Highest Lockup:">
+            {displayBalance(highest, true)}
           </AuctionPanelHeaderRow>
         </AuctionPanelHeader>
         <AuctionPanelFooter>

--- a/app/pages/Auction/BidActionPanel/Sold.js
+++ b/app/pages/Auction/BidActionPanel/Sold.js
@@ -81,7 +81,7 @@ class Sold extends Component {
           className="domains__action-panel__manage-domain-btn"
           onClick={() => history.push(`/domain_manager/${name}`)}
         >
-          View records
+          View domain details
         </button>
       </AuctionPanelFooter>
     )

--- a/app/pages/Auction/BidHistory.js
+++ b/app/pages/Auction/BidHistory.js
@@ -53,7 +53,7 @@ export default class BidHistory extends Component {
               <th>Date</th>
               <th>Address</th>
               <th>Bid</th>
-              <th>Mask</th>
+              <th>Lockup</th>
             </tr>
           </thead>
           <tbody>

--- a/app/pages/Auction/index.js
+++ b/app/pages/Auction/index.js
@@ -191,9 +191,10 @@ export default class Auction extends Component {
     const bids = domain.bids || domain.reveals || [];
     const pillContent = bids.length === 1 ? `${bids.length} bid` : `${bids.length} bids`;
 
-    if (isAvailable(domain) || isOpening(domain) || isBidding(domain) || isReveal(domain)) {
+    if (isAvailable(domain) || isOpening(domain) || isBidding(domain) || isReveal(domain) || isClosed(domain)) {
       return (
         <React.Fragment>
+
           <Collapsible className="domains__content__info-panel" title="Bids" pillContent={pillContent}>
             {this.props.domain ?
               <BidHistory
@@ -203,20 +204,26 @@ export default class Auction extends Component {
               'Loading...'
             }
           </Collapsible>
-          <Collapsible className="domains__content__info-panel" title="Vickrey Auction Process" defaultCollapsed>
-            <VickreyProcess />
-          </Collapsible>
+
+          {!isClosed(domain) ?
+            <Collapsible className="domains__content__info-panel" title="Vickrey Auction Process" defaultCollapsed>
+              <VickreyProcess />
+            </Collapsible> : null
+          }
+
+          {!isAvailable(domain) && domain.info ?
+            <Collapsible className="domains__content__info-panel" title="Records">
+              <Records
+                name={domain.name}
+                transferring={!!domain.info && domain.info.transfer !== 0}
+              />
+            </Collapsible> : null
+          }
+
         </React.Fragment>
       );
     } else {
-      return (
-        <Collapsible className="domains__content__info-panel" title="Records">
-          <Records
-            name={domain.name}
-            transferring={!!domain.info && domain.info.transfer !== 0}
-          />
-        </Collapsible>
-      );
+      return null;
     }
 
   }


### PR DESCRIPTION
(sorry, a bit bigger than I expected. Kept making small changes and ended up this way.)

### Changes in this PR
- Scrollbar appears only when bid list is longer than max-height (closes #119)
- Updated text (closes #93): Mask -> Lockup; Disguise -> Blind
- Show bids and records when appropriate (closes #160) - table for when exactly below
- Fixed Reveal Ends time (use `hoursUntilClose` instead of `stats.revealPeriodEnd` before, because this is block number, not time) - Doesn't show 7000+ days as reveal end anymore (https://github.com/kyokan/bob-wallet/issues/144#issuecomment-699511175)
- Update auction page (progress bars, etc.) as and when current block increases
- Fixed red warning when reveal period has just started - see screenshots 1 and 2
- Fixed Highest Lockup amount (replaced `domain.info.highest` with `Math.max(bids)`) + used displayBalance() for formatting - see screenshots 1 and 2
- Only attempt to show records after domain info is available (Loading...) - otherwise shows error in console

**Screenshot 1:** Old
![image](https://user-images.githubusercontent.com/5113343/112941530-5b493b00-914c-11eb-8c5e-ff43e5ebe39b.png)

**Screenshot 2:** New (at reveal period start block)
![image](https://user-images.githubusercontent.com/5113343/112943705-71a4c600-914f-11eb-8232-afbd4b960930.png)

**Screenshot 3:** New (during reveal period)
![image](https://user-images.githubusercontent.com/5113343/112945508-06102800-9152-11eb-904a-071c1c4ef75e.png)

#### Collapsibles shown on auction page at different states:
- New name without auction - Bids, Vickrey process
- During auction (opening, bidding, revealing): Bids, Vickrey process
- Closed state after auction (has domain info): Bids, Records
