### PR TITLE
hsd: bump hsd to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "electron-updater": "4.1.2",
     "history": "4.7.2",
     "hs-client": "https://github.com/handshake-org/hs-client.git",
-    "hsd": "https://github.com/kyokan/hsd/tarball/1e1292d",
+    "hsd": "https://github.com/kyokan/hsd/tarball/82dd02b",
     "isomorphic-fetch": "^2.2.1",
     "lodash.isequal": "4.5.0",
     "lodash.throttle": "4.1.1",


### PR DESCRIPTION
This PR updates bob to [this branch](https://github.com/kyokan/hsd/tree/kma2.3) of `kyokan/hsd`, which is rebased update to [this commit](https://github.com/handshake-org/hsd/commit/1a086e44b5b60e1ebb01955b0e1b2a0ebd00b42d) in `hsd`