### PR TITLE
Fix tx value for atomic name swap finalize

### DIFF
--- a/app/components/Transactions/Transaction/index.js
+++ b/app/components/Transactions/Transaction/index.js
@@ -59,18 +59,20 @@ class Transaction extends Component {
           || tx.type === COINBASE
           || tx.type === REVEAL
           || tx.type === REDEEM
-          || tx.type === REGISTER)
+          || tx.type === REGISTER
+          || (tx.type === FINALIZE && tx.value > 0))
         && !tx.pending,
       'transaction__number--neutral':
         (tx.type === UPDATE
           || tx.type === RENEW
           || tx.type === OPEN
           || tx.type === TRANSFER
-          || tx.type === FINALIZE)
+          || (tx.type === FINALIZE && tx.value === 0))
         && !tx.pending,
       'transaction__number--negative':
         (tx.type === SEND
-          || tx.type === BID)
+          || tx.type === BID
+          || (tx.type === FINALIZE && tx.value < 0))
         && !tx.pending,
     });
 
@@ -129,6 +131,8 @@ class Transaction extends Component {
       content = this.formatDomain(tx.meta.domain);
     } else if (tx.type === 'FINALIZE') {
       description = 'Finalized Domain';
+      if (tx.value > 0) description = 'Received Payment for Domain';
+      if (tx.value < 0) description = 'Finalized With Payment';
       content = this.formatDomain(tx.meta.domain);
     } else {
       description = 'Unknown Transaction';
@@ -153,9 +157,10 @@ class Transaction extends Component {
         {' '}
         {
           tx.type === RECEIVE || tx.type === COINBASE || tx.type === REDEEM || tx.type === REVEAL || tx.type === REGISTER ? '+'
-            : tx.type === UPDATE || tx.type === RENEW || tx.type === OPEN ? ''
+            : tx.type === UPDATE || tx.type === RENEW || tx.type === OPEN || tx.type === FINALIZE ? ''
             : '-'
         }
+        { (tx.type === FINALIZE && tx.value > 0) ? '+': '' }
         {displayBalance(tx.value)} HNS
       </div>
     </div>


### PR DESCRIPTION
Fixes #292.

The value for atomic name swaps show up as 0. This PR shows the +ve/-ve amount for seller/buyer.

**Note:** I could only test with 2 name swaps, probably needs more testing. Also not sure if this is the best way to get the values, it's the shortest I could think of.

For the example below, 2 names transferred, `c/` for **50 HNS**, `d/` **without payment**.

Sender:
![image](https://user-images.githubusercontent.com/5113343/105639487-a326ba00-5e9e-11eb-96e7-e31328c2efb7.png)

Receiver:
![image](https://user-images.githubusercontent.com/5113343/105639493-af127c00-5e9e-11eb-86d1-04db26ea7f88.png)

