### PR TITLE
domain-manager: fix expiry value in table

### DIFF
--- a/app/pages/DomainManager/index.js
+++ b/app/pages/DomainManager/index.js
@@ -389,17 +389,18 @@ export default withRouter(
 const DomainRow = connect(
   state => ({
     names: state.myDomains.names,
+    network: state.node.network,
   }),
 )(_DomainRow);
 
 function _DomainRow(props) {
-  const { name, names, onClick } = props;
+  const { name, names, onClick, network } = props;
   return (
     <TableRow key={`${name}`} onClick={onClick}>
       <TableItem>{formatName(name)}</TableItem>
       <TableItem>
         <Blocktime
-          height={names[name].height + 105120}
+          height={names[name].renewal + networks[network].names.renewalWindow}
           format="ll"
           fromNow
         />


### PR DESCRIPTION
Fixes #318.

Uses `ns.renewal` and the network's `renewalWindow` instead of `ns.height`.

![image](https://user-images.githubusercontent.com/5113343/114013790-90106d00-9885-11eb-8b23-b2346d627df2.png)
![image](https://user-images.githubusercontent.com/5113343/114013810-956db780-9885-11eb-8a7d-b19b706e1afb.png)
(for ref, taken today - 2020-04-08)
