### PR TITLE
Add ShakeDex fee support

### DIFF
--- a/app/background/shakedex/client.js
+++ b/app/background/shakedex/client.js
@@ -15,4 +15,5 @@ export const clientStub = ipcRendererInjector => makeClient(ipcRendererInjector,
   'restoreOneFill',
   'getExchangeAuctions',
   'listAuction',
+  'getFeeInfo',
 ]);

--- a/app/components/Modal/mini-modal.scss
+++ b/app/components/Modal/mini-modal.scss
@@ -30,6 +30,10 @@
 
 .mini-modal__content {
   padding-top: 27px;
+
+  p:nth-of-type(1) {
+    margin-top: 0;
+  }
 }
 
 .mini-modal--centered {

--- a/app/constants/explorers.js
+++ b/app/constants/explorers.js
@@ -3,25 +3,30 @@ export const EXPLORERS = [
     label: 'HNScan',
     tx: 'https://hnscan.com/tx/%s',
     name: 'https://hnscan.com/name/%s',
+    address: 'https://hnscan.com/address/%s',
   },
   {
     label: 'HNS Network',
     tx: 'https://hnsnetwork.com/txs/%s',
     name: 'https://hnsnetwork.com/names/%s',
+    address: 'https://hnsnetwork.com/address/%s',
   },
   {
     label: 'Shake Scan',
     tx: 'https://shakescan.com/transaction/%s',
     name: 'https://shakescan.com/name/%s',
+    address: 'https://shakescan.com/address/%s',
   },
   {
     label: 'HNS Fans',
     tx: 'https://e.hnsfans.com/tx/%s',
     name: 'https://e.hnsfans.com/name/%s',
+    address: 'https://e.hnsfans.com/address/%s',
   },
   {
     label: 'Handshake Explorer',
     tx: 'https://hnsxplorer.com/tx/%s',
     name: 'https://hnsxplorer.com/name/%s',
+    address: 'https://hnsxplorer.com/address/%s',
   },
 ]

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -100,6 +100,7 @@ class App extends Component {
       label: 'HNS Network',
       tx: 'https://hnsnetwork.com/txs/%s',
       name: 'https://hnsnetwork.com/names/%s',
+      address: 'https://hnsnetwork.com/address/%s',
     }
   }
 

--- a/app/pages/Exchange/ConfirmFeeModal.js
+++ b/app/pages/Exchange/ConfirmFeeModal.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { MiniModal } from '../../components/Modal/MiniModal.js';
+import { submitToShakedex } from '../../ducks/exchange.js';
+import { clientStub as sClientStub } from '../../background/shakedex/client.js';
+import { getPassphrase } from '../../ducks/walletActions.js';
+
+const shakedex = sClientStub(() => require('electron').ipcRenderer);
+
+export class ConfirmFeeModal extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isListing: false,
+    };
+  }
+
+  uploadListing = async () => {
+    this.setState({
+      isListing: true,
+    });
+    const {listing, feeInfo} = this.props;
+    const overrideParams = {
+      ...listing.params,
+      feeRate: feeInfo.rate,
+      feeAddr: feeInfo.addr,
+    };
+    const passphrase = await new Promise((resolve, reject) => this.props.getPassphrase(resolve, reject));
+    const regeneratedAuction = await shakedex.launchAuction(listing.nameLock, passphrase, overrideParams, false);
+    this.props.onClose();
+    await this.props.submitToShakedex(regeneratedAuction);
+
+  };
+
+  render() {
+    const {onClose, feeInfo} = this.props;
+
+    return (
+      <MiniModal title="Confirm Fee" onClose={onClose}>
+        <p>
+          The auction provider charges a fee of {feeInfo.rate / 100}%. Do you still want to post
+          your auctions?
+        </p>
+
+        <p>
+          <strong>Note:</strong> Your auction presigns will be regenerated prior to upload. However,
+          the presigns stored locally will remain without a fee.
+        </p>
+
+        <div className="place-bid-modal__buttons">
+          <button
+            className="place-bid-modal__cancel"
+            onClick={onClose}
+            disabled={this.props.isListing}
+          >
+            Cancel
+          </button>
+
+          <button
+            className="place-bid-modal__send"
+            onClick={this.uploadListing}
+            disabled={this.props.isListing}
+          >
+            {this.props.isListing ? 'Loading...' : 'Submit'}
+          </button>
+        </div>
+      </MiniModal>
+    );
+  }
+}
+
+export default connect(
+  () => ({}),
+  (dispatch) => ({
+    getPassphrase: (resolve, reject) => dispatch(getPassphrase(resolve, reject)),
+    submitToShakedex: (auction) => dispatch(submitToShakedex(auction)),
+  }),
+)(
+  ConfirmFeeModal,
+);

--- a/app/pages/Exchange/ConfirmFeeModal.js
+++ b/app/pages/Exchange/ConfirmFeeModal.js
@@ -4,6 +4,8 @@ import { MiniModal } from '../../components/Modal/MiniModal.js';
 import { submitToShakedex } from '../../ducks/exchange.js';
 import { clientStub as sClientStub } from '../../background/shakedex/client.js';
 import { getPassphrase } from '../../ducks/walletActions.js';
+import Hash from "../../components/Hash";
+import {shell} from "electron";
 
 const shakedex = sClientStub(() => require('electron').ipcRenderer);
 
@@ -34,12 +36,18 @@ export class ConfirmFeeModal extends Component {
   };
 
   render() {
-    const {onClose, feeInfo} = this.props;
+    const {onClose, feeInfo, explorer} = this.props;
+
+    const address = (
+      <b onClick={() => shell.openExternal(explorer.address.replace('%s', feeInfo.address))}>
+        <Hash value={feeInfo.address}/>
+      </b>
+    );
 
     return (
       <MiniModal title="Confirm Fee" onClose={onClose}>
         <p>
-          The auction provider charges a fee of {feeInfo.rate / 100}%. Do you still want to post
+          The auction provider charges a fee of <b>{feeInfo.rate / 100}%</b>. The fee will be sent to {address}. Do you still want to post
           your auctions?
         </p>
 
@@ -71,7 +79,9 @@ export class ConfirmFeeModal extends Component {
 }
 
 export default connect(
-  () => ({}),
+  state => ({
+    explorer: state.node.explorer,
+  }),
   (dispatch) => ({
     getPassphrase: (resolve, reject) => dispatch(getPassphrase(resolve, reject)),
     submitToShakedex: (auction) => dispatch(submitToShakedex(auction)),

--- a/app/pages/Exchange/exchange.scss
+++ b/app/pages/Exchange/exchange.scss
@@ -8,6 +8,10 @@
   }
 
   cursor: default;
+
+  &__auction-listing__row {
+    cursor: pointer;
+  }
 }
 
 .exchange__input {

--- a/app/pages/Exchange/index.js
+++ b/app/pages/Exchange/index.js
@@ -364,7 +364,6 @@ class Exchange extends Component {
             <HeaderItem>Name</HeaderItem>
             <HeaderItem>Status</HeaderItem>
             <HeaderItem>Amount</HeaderItem>
-            <HeaderItem>Fee</HeaderItem>
             <HeaderItem>Fill Placed At</HeaderItem>
             <HeaderItem />
           </HeaderRow>
@@ -374,7 +373,6 @@ class Exchange extends Component {
               <TableItem>{formatName(f.fulfillment.name)}</TableItem>
               <TableItem>{this.renderFulfillmentStatus(f.status)}</TableItem>
               <TableItem>{displayBalance(f.fulfillment.price, true)}</TableItem>
-              <TableItem>{displayBalance(f.fulfillment.fee || 0, true)}</TableItem>
               <TableItem>{moment(f.fulfillment.broadcastAt).format('MM/DD/YYYY HH:MM:SS')}</TableItem>
               <TableItem>
                 {[FULFILLMENT_STATUS.CONFIRMED].includes(f.status)  && (
@@ -631,7 +629,6 @@ class Exchange extends Component {
         <TableItem>{formatName(auction.name)}</TableItem>
         <TableItem>{displayBalance(currentBid?.price, true)}</TableItem>
         <TableItem>{this.renderNextBid(auction)}</TableItem>
-        <TableItem>{displayBalance(currentBid?.fee || 0, true)}</TableItem>
         <TableItem>
           {
             !auction.spendingStatus && (
@@ -699,7 +696,6 @@ function Header() {
       <HeaderItem>Name</HeaderItem>
       <HeaderItem>Current Bid</HeaderItem>
       <HeaderItem>Next Bid</HeaderItem>
-      <HeaderItem>Fee</HeaderItem>
       <HeaderItem />
     </HeaderRow>
   );

--- a/app/pages/Exchange/index.js
+++ b/app/pages/Exchange/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 import classNames from 'classnames';
 const {dialog} = require('electron').remote;
-
+import { shell } from 'electron';
 import { clientStub as aClientStub } from '../../background/analytics/client.js';
 import { clientStub as sClientStub } from '../../background/shakedex/client.js';
 import { HeaderItem, HeaderRow, Table, TableItem, TableRow } from '../../components/Table';
@@ -197,6 +197,7 @@ class Exchange extends Component {
 
   onClickSubmitShakedex = async (listing) => {
     const feeInfo = await shakedex.getFeeInfo();
+
     if (feeInfo.rate === 0) {
       return this.props.submitToShakedex(listing.auction);
     }
@@ -205,7 +206,7 @@ class Exchange extends Component {
       isShowingFeeConfirmationFor: listing,
       feeInfo,
     });
-  }
+  };
 
   renderListingStatus(status) {
     let statusText = status;
@@ -622,10 +623,13 @@ class Exchange extends Component {
     const currentBid = getCurrentBid(auction);
 
     return (
-      <TableRow key={auction.id}>
+      <TableRow
+        key={auction.id}
+        className="exchange__auction-listing__row"
+        onClick={() => shell.openExternal(`https://shakedex.com/a/${auction.name}`)}
+      >
         <TableItem>{formatName(auction.name)}</TableItem>
         <TableItem>{displayBalance(currentBid?.price, true)}</TableItem>
-        <TableItem>{displayBalance(auction.bids[0].price, true)}</TableItem>
         <TableItem>{this.renderNextBid(auction)}</TableItem>
         <TableItem>{displayBalance(currentBid?.fee || 0, true)}</TableItem>
         <TableItem>
@@ -634,16 +638,22 @@ class Exchange extends Component {
               <div className="exchange__auction-row-buttons">
                 <div
                   className="bid-action__link"
-                  onClick={() => this.setState({
-                    placingAuction: auction,
-                    placingCurrentBid: currentBid,
-                  })}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    this.setState({
+                      placingAuction: auction,
+                      placingCurrentBid: currentBid,
+                    });
+                  }}
                 >
                   Fill
                 </div>
                 <div
                   className="bid-action__link"
-                  onClick={() => this.onClickDownload(auction)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    this.onClickDownload(auction);
+                  }}
                 >
                   Download Proofs
                 </div>
@@ -688,7 +698,6 @@ function Header() {
     <HeaderRow>
       <HeaderItem>Name</HeaderItem>
       <HeaderItem>Current Bid</HeaderItem>
-      <HeaderItem>Starting Bid</HeaderItem>
       <HeaderItem>Next Bid</HeaderItem>
       <HeaderItem>Fee</HeaderItem>
       <HeaderItem />

--- a/app/utils/shakedex.js
+++ b/app/utils/shakedex.js
@@ -85,6 +85,10 @@ export const auctionSchema = {
             type: 'integer',
             minimum: 0,
           },
+          fee: {
+            type: 'integer',
+            minimum: 0,
+          },
           lockTime: {
             type: 'integer',
             minimum: 1610000000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13934,6 +13934,16 @@
             "minipass": "^3.0.0"
           }
         },
+        "hs-client": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.9.tgz",
+          "integrity": "sha512-TAsexmpPhSVdCQ1iiX4bBnuqlThTSdGz/YKq+vjLSS1TZ2TwKxERJ8vZh1Wd6GGaMGLZl99uQR+2wUyk4HLSbg==",
+          "requires": {
+            "bcfg": "~0.1.6",
+            "bcurl": "~0.1.9",
+            "bsert": "~0.0.10"
+          }
+        },
         "hsd": {
           "version": "https://github.com/handshake-org/hsd/tarball/a94ce87",
           "integrity": "sha512-C/5Exa/H5AYahDf7V0ggG6vdlp3252R+A0k15ckFM/LIHdbSf/TVzJsefWKNDI/V6vktpP6Edhuj+FtYSH7LOg==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-wallet",
-  "version": "0.7.0-rc.4",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4144,17 +4144,17 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "requires": {
-        "type-fest": "^0.11.0"
+        "type-fest": "^0.21.3"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
         }
       }
     },
@@ -13892,9 +13892,9 @@
       }
     },
     "shakedex": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/shakedex/-/shakedex-0.0.10.tgz",
-      "integrity": "sha512-E+rZkzp0/d3L518k/gH1jNbJjA/ReqwHHYDYZLjmENT9TEcZWCgS9kFzyqVZgNLBtU2SeH5+gprdZLik6eeZYA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/shakedex/-/shakedex-0.0.12.tgz",
+      "integrity": "sha512-lbdFocFAimG28Zm6GDbIG4l4A496RzQHAXPFUP1xBwnB5EpdMMLNBXYGwA+X6toJqSSc0iLyIcs9oYZrFtOsxQ==",
       "requires": {
         "bcrypto": "5.4.0",
         "bcurl": "^0.1.9",
@@ -13907,9 +13907,15 @@
         "inquirer": "7.3.3",
         "level": "6.0.1",
         "node-fetch": "2.6.1",
-        "password-prompt": "1.1.2"
+        "password-prompt": "1.1.2",
+        "tar": "6.1.0"
       },
       "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
         "commander": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.0.0.tgz",
@@ -13920,14 +13926,12 @@
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.17.0.tgz",
           "integrity": "sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA=="
         },
-        "hs-client": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.9.tgz",
-          "integrity": "sha512-TAsexmpPhSVdCQ1iiX4bBnuqlThTSdGz/YKq+vjLSS1TZ2TwKxERJ8vZh1Wd6GGaMGLZl99uQR+2wUyk4HLSbg==",
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "requires": {
-            "bcfg": "~0.1.6",
-            "bcurl": "~0.1.9",
-            "bsert": "~0.0.10"
+            "minipass": "^3.0.0"
           }
         },
         "hsd": {
@@ -13963,10 +13967,50 @@
             "urkel": "~0.7.0"
           }
         },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
         "node-fetch": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
           "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
+        "tar": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+          "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "redux-thunk": "2.3.0",
     "rimraf": "2.6.2",
     "sha3": "2.0.0",
-    "shakedex": "0.0.10",
+    "shakedex": "0.0.12",
     "source-map-support": "0.5.9",
     "tcp-port-used": "1.0.1",
     "uuid": "3.3.3",


### PR DESCRIPTION
This PR upgrades Bob to support ShakeDex fees. Note that the API endpoints are currently disabled on shakedex web, so all mainnet fees will be zero.

Screenshots are attached. Some janky UI I wasn't sure how to fix, but the bones should be there!

<img width="524" alt="Screen Shot 2021-04-09 at 12 38 25 AM" src="https://user-images.githubusercontent.com/78248217/114139313-1e0f4680-98cc-11eb-939c-8b75f47ebcec.png">
<img width="750" alt="Screen Shot 2021-04-09 at 12 37 44 AM" src="https://user-images.githubusercontent.com/78248217/114139315-1ea7dd00-98cc-11eb-9f0d-5d1c5f531c25.png">
