### PR TITLE
Speed up IBD: Don't estimate fee until synced + use worker threads

### DIFF
--- a/app/background/node/service.js
+++ b/app/background/node/service.js
@@ -86,7 +86,7 @@ export class NodeService extends EventEmitter {
       logConsole: false,
       logLevel: 'debug',
       memory: false,
-      workers: false,
+      workers: true,
       network: this.networkName,
       loader: require,
       prefix: this.hsdPrefixDir,

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -790,7 +790,6 @@ class WalletService {
 
   refreshNodeInfo = async () => {
     const info = await nodeService.getInfo().catch(() => null);
-    const fees = await nodeService.getFees().catch(() => null);
 
     if (info) {
       const {chain: {height: chainHeight}} = info;
@@ -801,13 +800,17 @@ class WalletService {
         type: SET_NODE_INFO,
         payload: { info },
       });
-    }
 
-    if (fees) {
-      dispatchToMainWindow({
-        type: SET_FEE_INFO,
-        payload: { fees },
-      });
+      let fees;
+      if (info.chain.progress > 0.99)
+        fees = await nodeService.getFees().catch(() => null);     
+
+      if (fees) {
+        dispatchToMainWindow({
+          type: SET_FEE_INFO,
+          payload: { fees },
+        });
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "electron-updater": "4.1.2",
     "history": "4.7.2",
     "hs-client": "https://github.com/handshake-org/hs-client.git",
-    "hsd": "https://github.com/handshake-org/hsd/tarball/375ef41",
+    "hsd": "https://github.com/pinheadmz/hsd/tarball/00c78c488807417dd5ac15b20e079b4697b576c5",
     "isomorphic-fetch": "^2.2.1",
     "jsonschema": "^1.4.0",
     "lodash.isequal": "4.5.0",


### PR DESCRIPTION
This PR is an experimental integration test of https://github.com/handshake-org/hsd/pull/592 along with one other performance improvement: not calling `rpc estimatesmartfee` three times after every single block! With this PR, at least wait until we are (almost) fully synced before bothering hsd about that...

