### PR TITLE
shakedex: use node api key in context

### DIFF
--- a/app/background/shakedex/service.js
+++ b/app/background/shakedex/service.js
@@ -427,14 +427,23 @@ async function downloadProofs(auctionJSON) {
 }
 
 function getContext(passphrase = null) {
-  const walletId = walletService.name;
-  const {apiKey, networkName} = nodeService;
+  const {
+    name: walletId,
+    walletApiKey,
+  } = walletService;
+  const {
+    apiKey: nodeApiKey,
+    networkName,
+    client,
+  } = nodeService;
 
   return new Context(
     networkName,
     walletId,
-    apiKey,
+    walletApiKey,
     () => Promise.resolve(passphrase),
+    client.host,
+    nodeApiKey,
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-wallet",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13892,9 +13892,8 @@
       }
     },
     "shakedex": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/shakedex/-/shakedex-0.0.12.tgz",
-      "integrity": "sha512-lbdFocFAimG28Zm6GDbIG4l4A496RzQHAXPFUP1xBwnB5EpdMMLNBXYGwA+X6toJqSSc0iLyIcs9oYZrFtOsxQ==",
+      "version": "git+https://github.com/chikeichan/shakedex.git#f9641a8f133983f5e677f7484f9e0770786e86e4",
+      "from": "git+https://github.com/chikeichan/shakedex.git#f9641a8",
       "requires": {
         "bcrypto": "5.4.0",
         "bcurl": "^0.1.9",
@@ -13932,16 +13931,6 @@
           "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "requires": {
             "minipass": "^3.0.0"
-          }
-        },
-        "hs-client": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.9.tgz",
-          "integrity": "sha512-TAsexmpPhSVdCQ1iiX4bBnuqlThTSdGz/YKq+vjLSS1TZ2TwKxERJ8vZh1Wd6GGaMGLZl99uQR+2wUyk4HLSbg==",
-          "requires": {
-            "bcfg": "~0.1.6",
-            "bcurl": "~0.1.9",
-            "bsert": "~0.0.10"
           }
         },
         "hsd": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "redux-thunk": "2.3.0",
     "rimraf": "2.6.2",
     "sha3": "2.0.0",
-    "shakedex": "0.0.12",
+    "shakedex": "https://github.com/chikeichan/shakedex#f9641a8",
     "source-map-support": "0.5.9",
     "tcp-port-used": "1.0.1",
     "uuid": "3.3.3",


### PR DESCRIPTION
This PR uses [this specific commit](https://github.com/kurumiimari/shakedex/pull/21) in shakedex so that node api and wallet api key can be different. 