### PR TITLE
Fix record type when deserializing GLUE6

### DIFF
--- a/app/utils/recordHelpers.js
+++ b/app/utils/recordHelpers.js
@@ -154,7 +154,7 @@ const deserializers = {
     }
 
     return {
-      type: RECORD_TYPE.GLUE4,
+      type: RECORD_TYPE.GLUE6,
       ns: parts[0],
       address: parts[1],
     };


### PR DESCRIPTION
Return GLUE6 record type for the deserialized GLUE6 string rather than GLUE4.

See behavior as-is:
![image](https://user-images.githubusercontent.com/4912057/115644820-0d030400-a2d4-11eb-9107-95eab19b4e19.png)
