### PR TITLE
Upgrade shakedex to 0.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9690,9 +9690,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -13892,8 +13892,9 @@
       }
     },
     "shakedex": {
-      "version": "git+https://github.com/chikeichan/shakedex.git#f9641a8f133983f5e677f7484f9e0770786e86e4",
-      "from": "git+https://github.com/chikeichan/shakedex.git#f9641a8",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/shakedex/-/shakedex-0.0.15.tgz",
+      "integrity": "sha512-2LqpOp/yNB7VhV+sBRa7ltEsD2aLHND0/jRTGgXyJ2/j4EFEMy0nghH49HCQgaivy89Np3T9p9vXg66cI9VRzQ==",
       "requires": {
         "bcrypto": "5.4.0",
         "bcurl": "^0.1.9",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "redux-thunk": "2.3.0",
     "rimraf": "2.6.2",
     "sha3": "2.0.0",
-    "shakedex": "https://github.com/chikeichan/shakedex#f9641a8",
+    "shakedex": "0.0.15",
     "source-map-support": "0.5.9",
     "tcp-port-used": "1.0.1",
     "uuid": "3.3.3",


### PR DESCRIPTION
Hi @chikeichan,

This PR upgrades ShakeDex to 0.0.15. This release includes your PR, and fixes a critical bug that prevents auctions from being fulfilled using coins that are less than `coinbaseMaturity` blocks old. Essentially, this meant that all ShakeDex coins had to be at least 100 blocks old.

Let me know if you have any feedback and I'll fix it quickly. You can see the diff between the previous version of ShakeDex  and this one [here](https://github.com/kurumiimari/shakedex/compare/1274b1d2327cc1f763175ce4cf058f34e49b1acb..0d1943f69047d60a530d5d7fd028291247c4e64c). Thank you!