### PR TITLE
yourBids: add filter by bid status

### DIFF
--- a/app/ducks/bids.js
+++ b/app/ducks/bids.js
@@ -1,23 +1,57 @@
 import walletClient from '../utils/walletClient';
 
 const SET_YOUR_BIDS = 'app/bids/setYourBids';
+const SET_BIDS_FILTER = 'app/bids/setBidsFilter';
 
 const initialState = {
-  yourBids: [],
+  map: {},
+  order: [],
+  filter: {
+    OPENING: [],
+    BIDDING: [],
+    REVEAL: [],
+    CLOSED: [],
+    TRANSFER: [],
+  },
 };
 
-export const setYourBids = (bids = []) => ({
+export const setYourBids = ({ order, map }) => ({
   type: SET_YOUR_BIDS,
-  payload: bids,
+  payload: {
+    order,
+    map,
+  },
+});
+
+export const setFilter = (filter = {}) => ({
+  type: SET_BIDS_FILTER,
+  payload: filter,
 });
 
 export const getYourBids = () => async (dispatch) => {
-  const result = await walletClient.getBids();
+  const {bids, filter} = await walletClient.getBids();
 
-  const yourBids = result.filter(({ own }) => own);
+  const yourBids = bids.filter(({ own }) => own);
 
-  if (result && result.length) {
-    dispatch(setYourBids(yourBids));
+  const order = yourBids.map(bid => {
+    return bid.prevout.hash + bid.prevout.index;
+  });
+
+  const map = yourBids.reduce((acc, bid) => {
+    const id = bid.prevout.hash + bid.prevout.index;
+    acc[id] = bid;
+    return acc;
+  }, {});
+
+  if (yourBids && yourBids.length) {
+    dispatch(setYourBids({ order, map }));
+    dispatch(setFilter({
+      OPENING: filter.OPENING.filter(id => !!map[id]),
+      BIDDING: filter.BIDDING.filter(id => !!map[id]),
+      REVEAL: filter.REVEAL.filter(id => !!map[id]),
+      CLOSED: filter.CLOSED.filter(id => !!map[id]),
+      TRANSFER: filter.TRANSFER.filter(id => !!map[id]),
+    }));
   }
 };
 
@@ -26,7 +60,15 @@ export default function bidsReducer(state = initialState, action) {
 
   switch (type) {
     case SET_YOUR_BIDS:
-      return {...state, yourBids: payload};
+      return {
+        ...state,
+        ...payload,
+      };
+    case SET_BIDS_FILTER:
+      return {
+        ...state,
+        filter: payload,
+      };
     default:
       return state;
   }

--- a/app/ducks/walletActions.js
+++ b/app/ducks/walletActions.js
@@ -22,7 +22,7 @@ import {
 } from './walletReducer';
 import { NEW_BLOCK_STATUS } from './nodeReducer';
 import {setNames} from "./myDomains";
-import {setYourBids} from "./bids";
+import {setFilter, setYourBids} from "./bids";
 
 let idleInterval;
 
@@ -142,7 +142,17 @@ export const unlockWallet = (name, passphrase) => async (dispatch, getState) => 
     });
 
     dispatch(setNames({}));
-    dispatch(setYourBids([]));
+    dispatch(setYourBids({
+      order: [],
+      map: {},
+    }));
+    dispatch(setFilter({
+      OPENING: [],
+      BIDDING: [],
+      REVEAL: [],
+      CLOSED: [],
+      TRANSFER: [],
+    }))
   }
 
   dispatch({
@@ -411,7 +421,7 @@ async function parseInputsOutputs(net, tx) {
         // If yes, sum all outputs to others' addresses (payment made to sender)
         const containsOtherOutputs = tx.outputs.findIndex(x => x.covenant.action == 'NONE' && x.path !== null) !== -1;
         if (containsOtherOutputs) covValue = -tx.outputs.reduce((sum, op) => !op.path ? (sum+op.value) : sum, 0);
-      }      
+      }
     }
 
     // Renewals and Updates have a value, but it doesn't

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -199,8 +199,8 @@ class App extends Component {
           <ProtectedRoute
             isLocked={this.props.isLocked}
             wallets={this.props.wallets}
-            path="/bids"
-            render={this.routeRenderer('Domains', YourBids)}
+            path="/bids/:filterType?"
+            render={this.routeRenderer('Bid History', YourBids)}
           />
           <ProtectedRoute
             isLocked={this.props.isLocked}

--- a/app/pages/YourBids/BidAction.js
+++ b/app/pages/YourBids/BidAction.js
@@ -25,8 +25,6 @@ class BidAction extends Component {
     } = this.props;
 
     getNameInfo(name);
-
-
   }
 
   isReveal = () => isReveal(this.props.domain);

--- a/app/pages/YourBids/index.js
+++ b/app/pages/YourBids/index.js
@@ -57,7 +57,6 @@ class YourBids extends Component {
     this.props.getYourBids()
       .then(() => this.setState({ loading: false }));
     const itemsPerPage = await dbClient.get(YOUR_BIDS_ITEMS_PER_PAGE_KEY);
-    console.log(this.props.match.params.filterType)
     this.setState({
       itemsPerPage: itemsPerPage || 10,
       activeFilter: this.props.match.params.filterType || '',

--- a/app/pages/YourBids/your-bids.scss
+++ b/app/pages/YourBids/your-bids.scss
@@ -21,6 +21,23 @@
     }
   }
 
+  &__filters {
+    @extend %row-nowrap;
+    flex-wrap: wrap;
+    margin: 1rem 0;
+  }
+
+  &__filter {
+    margin-right: 1rem;
+    cursor: pointer;
+    color: $azure-blue;
+
+    &--active {
+      cursor: default;
+      color: $black;
+    }
+  }
+
   &__search {
     margin: 1rem 0;
     width: 10rem;


### PR DESCRIPTION
`getBids` will re-index every bids calling `wallet.getNameStateByName`. This limits network/rpc even locally, as even local rpc call is still a web request that adds overhead. I perf tested this with a wallet that has about 9k bid history on almost as many names, and the loading time with filter feels the same as loading time without filters.

![bidfilter](https://user-images.githubusercontent.com/8507735/121664223-1bf86e00-ca5c-11eb-9a0e-ca15576c06a5.gif)
