### PR TITLE
Remote RPC: enable https

### DIFF
--- a/app/background/node/service.js
+++ b/app/background/node/service.js
@@ -307,20 +307,17 @@ export class NodeService extends EventEmitter {
       apiKey,
     } = rpc;
 
-    const portString = port ? `:${port}` : '';
-    const pathString = (!pathname || pathname === '/') ? '' : pathname;
-    const protoString = protocol || 'http';
-
-    const url = `${protoString}://${host}${portString}${pathString}`;
-
     // Not really used after this point,
     // but overwrite the local getAPIKey() just in case.
     this.apiKey = apiKey;
 
     return new NodeClient({
-      network: this.network,
       apiKey,
-      url,
+      ssl: protocol === 'https',
+      host,
+      port: parseInt(port, 10),
+      path: pathname,
+      timeout: 30000,
     });
   }
 

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -158,8 +158,9 @@ class WalletService {
     this.node = new WalletNode({
       network: this.networkName,
       nodeHost: this.conn.host,
-      nodePort: this.conn.port || undefined,
+      nodePort: parseInt(this.conn.port, 10),
       nodeApiKey: this.conn.apiKey,
+      nodeSSL: this.conn.protocol === 'https',
       apiKey: this.walletApiKey,
       memory: false,
       prefix: HSD_DATA_DIR,

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -163,7 +163,6 @@ class WalletService {
       apiKey: this.walletApiKey,
       memory: false,
       prefix: HSD_DATA_DIR,
-      migrate: 0,
       logFile: true,
       logConsole: false,
       logLevel: 'debug',

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -155,12 +155,25 @@ class WalletService {
       payload: this.walletApiKey,
     });
 
+    // This is an unfortunate work-around for the fact that
+    // WalletNode doesn't accept a `nodePath` option to 
+    // pass to NodeClient which gets passed to bcurl/client.
+    const nodeURL =
+      this.conn.pathname
+      ?
+        this.conn.protocol + '://' +
+        'username_is_ignored:' + this.conn.apiKey + '@' +
+        this.conn.host + ':' + this.conn.port + this.conn.pathname
+      :
+        null;
+
     this.node = new WalletNode({
       network: this.networkName,
       nodeHost: this.conn.host,
       nodePort: parseInt(this.conn.port, 10),
       nodeApiKey: this.conn.apiKey,
       nodeSSL: this.conn.protocol === 'https',
+      nodeURL,
       apiKey: this.walletApiKey,
       memory: false,
       prefix: HSD_DATA_DIR,

--- a/app/pages/Settings/CustomRPCConfigModal.js
+++ b/app/pages/Settings/CustomRPCConfigModal.js
@@ -206,7 +206,7 @@ export default class CustomRPCConfigModal extends Component {
             className="network-picker custom-rpc__network-picker"
             items={[
               { label: 'http', value: 'http' },
-              // { label: 'https', value: 'https' },
+              { label: 'https', value: 'https' },
             ]}
             currentIndex={['http', 'https'].indexOf(protocol)}
             onChange={(value) => this.setState({


### PR DESCRIPTION
Closes https://github.com/kyokan/bob-wallet/issues/411

Reviewers can test by opening Bob in dev mode in REGTEST and configuring my hosted regtest node as the remote:


protocol: `https`
host: `hns-contributor.dev`
path:
Network Type: `Regtest`
port: `14037`
API key: `hellogoodbye-whatsmyname-123`

There is one stupid hack here because in hsd `WalletNode` has no option for `path` so if `pathname` is set by user, we have to assemble a URL and pass that as the `nodeURL` option to `WalletNode` 🤷‍♂️ 

TODO:
- [ ] test with path: I'm having trouble setting up a reverse proxy for this just to test an alternate path
- [x] clean up RPC config modal: the placeholders look like values and you have to re-type to enter data

**LONG-TERM TODO:** Allow self-signed cert pinning so remote rpc can connect over https without legacy CA