### PR TITLE
Sync fixes

### DIFF
--- a/app/background/node/service.js
+++ b/app/background/node/service.js
@@ -355,12 +355,12 @@ export class NodeService extends EventEmitter {
 
     try {
       const info = await this.getInfo();
+      this.emit('refreshNodeInfo', info);
 
       dispatchToMainWindow({
         type: SET_NODE_INFO,
         payload: info.chain,
       });
-
 
       if (info.chain.progress > 0.99) {
         const fees = await this.getFees();

--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -1050,6 +1050,8 @@ class WalletService {
       type: SYNC_WALLET_PROGRESS,
       payload: entry.height,
     });
+
+    this.lastKnownChainHeight = entry.height;
   };
 
   /**
@@ -1061,6 +1063,8 @@ class WalletService {
    */
 
   onRescanBlock = async (entry) => {
+    this.lastKnownChainHeight = entry.height;
+
     if (entry.height === nodeService.height) {
       dispatchToMainWindow({type: STOP_SYNC_WALLET});
       dispatchToMainWindow({


### PR DESCRIPTION
fixes #448, fixes #455, fixes #429

`lastKnownChainHeight` was never being set in `Wallet` service. And wallet sync never stopped because the node's height wasn't available (was always 0).
Without lastKnownChainHeight, the namestate of each name used in Your Bids page was being retrieved as of height 0, not current height.

Now, both are updated in Wallet service on events from wallet and node.

