### PR TITLE
Splash screen msg for port conflict/other errors + misc

### DIFF
--- a/app/background/node/service.js
+++ b/app/background/node/service.js
@@ -143,7 +143,6 @@ export class NodeService extends EventEmitter {
           } else {
             throw error;
           }
-          return;
         }
         await this.setHSDLocalClient();
         dispatchToMainWindow({

--- a/app/ducks/node.js
+++ b/app/ducks/node.js
@@ -11,6 +11,7 @@ import {
   SET_FEE_INFO,
   SET_CUSTOM_RPC_STATUS,
   START_NETWORK_CHANGE,
+  START_ERROR,
   STOP,
   START_NODE_STATUS_CHANGE,
   START_RPC_TEST,
@@ -88,6 +89,7 @@ export const start = (network) => async (dispatch) => {
   } catch (error) {
     console.error('node start error', error);
     dispatch({ type: STOP });
+    dispatch({ type: START_ERROR, payload: error.message });
   } finally {
     dispatch({ type: END_NODE_STATUS_CHANGE });
   }

--- a/app/ducks/nodeReducer.js
+++ b/app/ducks/nodeReducer.js
@@ -84,7 +84,7 @@ export default function nodeReducer(state = getInitialState(), action = {}) {
         },
       };
     case START_ERROR:
-      return {...state, error: action.payload.error};
+      return {...state, error: action.payload};
     case SET_NODE_INFO:
       return {
         ...state,

--- a/app/pages/App/index.js
+++ b/app/pages/App/index.js
@@ -302,11 +302,15 @@ const OPEN_ROUTES = [
 ]
 
 const ProtectedRoute = (props) => {
+  if (OPEN_ROUTES.includes(props.location.pathname)) {
+    return <Route {...props} />;
+  }
+
   if (!props.wallets.length) {
     return <Redirect to="/funding-options" />;
   }
 
-  if (props.isLocked && !OPEN_ROUTES.includes(props.location.pathname)) {
+  if (props.isLocked) {
     return <Redirect to="/login" />;
   }
 

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "semver": "^7.3.5",
     "shakedex": "https://github.com/chikeichan/shakedex#patch-3",
     "source-map-support": "0.5.21",
-    "tcp-port-used": "1.0.1",
     "uuid": "3.3.3",
     "winston": "3.1.0"
   }


### PR DESCRIPTION
After the wallet plugin refactor, splash screen stopped showing errors when node failed to start. That's fixed as well as:
- Handled error for EADDRINUSE and replaced with message including ip and port
- Removed dependency `tcp-port-used`
- Re-ordered checks in ProtectedRoute to allow opening settings when no wallets exist
- Removed unused imports