### PR TITLE
Change the report url to github new issue link

### DIFF
--- a/app/components/Notification/index.js
+++ b/app/components/Notification/index.js
@@ -80,7 +80,7 @@ export default class Notification extends Component {
         <div
           className="notification__issue-wrapper__action"
           onClick={() => {
-            require("electron").shell.openExternal("https://forum.kyokan.io/c/bob/support/5");
+            require("electron").shell.openExternal("https://github.com/kyokan/bob-wallet/issues/new");
           }}
         >
           Create Bug Report

--- a/app/menu.js
+++ b/app/menu.js
@@ -165,7 +165,7 @@ export default class MenuBuilder {
         {
           label: 'Report an Issue',
           click() {
-            shell.openExternal('https://forum.kyokan.io/c/bob/support/5');
+            shell.openExternal('https://github.com/kyokan/bob-wallet/issues/new');
           }
         }
       ]
@@ -246,7 +246,7 @@ export default class MenuBuilder {
           {
             label: 'Report an Issue',
             click() {
-              shell.openExternal('https://forum.kyokan.io/c/bob/support/5');
+              shell.openExternal('https://github.com/kyokan/bob-wallet/issues/new');
             }
           }
         ]


### PR DESCRIPTION
Since the previous link doesn't work, I think the github new issue link is a good replacement.