### PR TITLE
node: use different wallet api key

### DIFF
--- a/app/background/wallet/service.js
+++ b/app/background/wallet/service.js
@@ -90,11 +90,13 @@ class WalletService {
     this.networkName = this.network.type;
     this.walletApiKey = apiKey;
 
-    await this.setAPIKey(apiKey);
-
     dispatchToMainWindow({
       type: SET_WALLET_NETWORK,
       payload: this.networkName,
+    });
+    dispatchToMainWindow({
+      type: SET_API_KEY,
+      payload: this.walletApiKey,
     });
 
     // TODO: This may not work because the plugin is open() already by now

--- a/app/pages/Settings/APIKeyModal.js
+++ b/app/pages/Settings/APIKeyModal.js
@@ -1,12 +1,28 @@
 import MiniModal from "../../components/Modal/MiniModal";
 import React, {Component} from "react";
+import {connect} from "react-redux";
+import {withRouter} from "react-router-dom";
 import PropTypes from "prop-types";
 import crypto from "crypto";
 import Alert from "../../components/Alert";
 import {I18nContext} from "../../utils/i18n";
+import * as nodeActions from '../../ducks/node';
 
+@withRouter
+@connect(
+  (state) => ({}),
+  dispatch => ({
+    stopNode: () => dispatch(nodeActions.stop()),
+    startNode: () => dispatch(nodeActions.start()),
+  }),
+)
 export default class APIKeyModal extends Component {
   static propTypes = {
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired
+    }).isRequired,
+    stopNode: PropTypes.func.isRequired,
+    startNode: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
     closeRoute: PropTypes.string.isRequired,
     apiKey: PropTypes.string.isRequired,
@@ -39,9 +55,14 @@ export default class APIKeyModal extends Component {
       });
     }
 
+    await this.props.stopNode();
+    await this.props.startNode();
+
     this.setState({
       saving: false,
     });
+
+    this.props.history.goBack();
   };
 
   render() {
@@ -58,9 +79,6 @@ export default class APIKeyModal extends Component {
         closeRoute={closeRoute}
         title={title}
       >
-        <Alert type="warning">
-          {t('settingAPIKeyWarning')}
-        </Alert>
         <div className="settings__input-row">
           <div className="settings__input-title">
             {t('apiKey')}

--- a/locales/XXXXX.json
+++ b/locales/XXXXX.json
@@ -370,7 +370,6 @@
   "setReminder": "XXXXX",
   "settingAPIKeyCTA": "XXXXX",
   "settingAPIKeyDesc": "XXXXX",
-  "settingAPIKeyWarning": "XXXXX",
   "settingBackupListingDesc": "XXXXX",
   "settingBackupListingTitle": "XXXXX",
   "settingBackupWDBDesc": "XXXXX",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -370,7 +370,6 @@
   "setReminder": "Establir recordatori",
   "settingAPIKeyCTA": "Mostra la clau de l'API",
   "settingAPIKeyDesc": "Clau API per a hs-client. Assegurat de seleccionar l'identificador del wallet \"%s\".",
-  "settingAPIKeyWarning": "La clau de l'API només es farà efectiva després de reiniciar Bob.",
   "settingBackupListingDesc": "Baixa una còpia de seguretat de totes les teves fitxes i acompliments",
   "settingBackupListingTitle": "Llista de còpia de seguretat",
   "settingBackupWDBDesc": "Fes una còpia de seguretat de la base de dades i dels fitxers de la wallet a un directori.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -387,7 +387,6 @@
   "setReminder": "Set reminder",
   "settingAPIKeyCTA": "View API Key",
   "settingAPIKeyDesc": "API key for hs-client. Make sure you select the wallet id \"%s\".",
-  "settingAPIKeyWarning": "API Key will only take effect after you restart Bob.",
   "settingBackupListingDesc": "Download backup of all your listings and fulfillments",
   "settingBackupListingTitle": "Backup listing",
   "settingBackupWDBDesc": "Back up wallet database and files to a directory.",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -370,7 +370,6 @@
   "setReminder": "Establecer recordatorio",
   "settingAPIKeyCTA": "Muestra la clave de la API",
   "settingAPIKeyDesc": "Clave API para hs-client. Asegúrese de seleccionar la identificación de la wallet \"%s\".",
-  "settingAPIKeyWarning": "La clave de la API sólo se hará efectiva después de reiniciar Bob.",
   "settingBackupListingDesc": "Baja una copia de seguridad de todas tus fichas y cumplimientos",
   "settingBackupListingTitle": "Lista de copia de seguridad",
   "settingBackupWDBDesc": "Haz una copia de seguridad de la base de datos y de los archivos de la wallet a un directorio.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -350,7 +350,6 @@
   "sendTxTimeLabel": "Transaction time",
   "setReminder": "Set reminder",
   "settingAPIKeyCTA": "View API Key",
-  "settingAPIKeyWarning": "API Key will only take effect after you restart Bob.",
   "settingBackupListingDesc": "Download backup of all your listings and fulfillments",
   "settingBackupListingTitle": "Backup listing",
   "settingBackupWDBDesc": "Back up wallet database and files to a directory.",


### PR DESCRIPTION
Closes #484.

Instead of using node's api key for wallet also, first check if wallet has a custom api key in db already.

New behavior:
- On fresh start, node and wallet get a newly generated random api key (same for node and wallet)
- (wallet as plugin) node or wallet api key can be individally changed in settings without affecting the other

RPC is not modified, it just uses the custom wallet api key if stored in db or generates (and stores) one.
