### PR TITLE
Mention releases in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-#  Changelog
+**All notable changes to this project are documented in [releases](https://github.com/kyokan/bob-wallet/releases). This file is kept for legacy purposes.**
 
-All notable changes to this project will be documented in this file.
+#  Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
See https://github.com/kyokan/bob-wallet/pull/606.

>Instead of having different styles in the file, we can stick to your original suggestion: linking to the releases page at the top of the file. Easier and we won't have to rewrite for past (and future) notes.

Done so.  

Alternatively we could still keep updating CHANGELOG.md by simply referencing to releases on every version release like the following:  

>## [2.0.0] - 2023-02-15
>
>See https://github.com/kyokan/bob-wallet/releases/tag/v2.0.0.

I don't see much value in such changelog entries though. Probably just to raise awareness about new versions. Many devs are used to CHANGELOG.md as a source of updates I believe. Likely a better solution than a frozen changelog. WDYT?