### PR TITLE
ui: add jump to page number in paginated tables

### DIFF
--- a/app/components/Transactions/index.scss
+++ b/app/components/Transactions/index.scss
@@ -195,6 +195,19 @@
       align-items: center;
     }
 
+    &__input {
+      @extend %box-input;
+      @extend %row-nowrap;
+
+      width: 2rem;
+      padding: .35rem .5rem;
+
+      input {
+        @extend %h4;
+        text-align: center;
+      }
+    }
+
     &__dropdowns {
       @extend %row-nowrap;
       align-items: center;

--- a/app/pages/DomainManager/domain-manager.scss
+++ b/app/pages/DomainManager/domain-manager.scss
@@ -145,6 +145,19 @@
       align-items: center;
     }
 
+    &__input {
+      @extend %box-input;
+      @extend %row-nowrap;
+
+      width: 2rem;
+      padding: .35rem .5rem;
+
+      input {
+        @extend %h4;
+        text-align: center;
+      }
+    }
+
     &__dropdowns {
       @extend %row-nowrap;
       align-items: center;

--- a/app/pages/DomainManager/index.js
+++ b/app/pages/DomainManager/index.js
@@ -52,6 +52,7 @@ class DomainManager extends Component {
     isShowingBulkTransfer: false,
     isConfirmingBulkFinalize: false,
     currentPageIndex: 0,
+    isEditingPageIndex: false,
     itemsPerPage: 10,
   };
 
@@ -63,6 +64,7 @@ class DomainManager extends Component {
       || this.state.isShowingBulkTransfer !== nextState.isShowingBulkTransfer
       || this.state.isConfirmingBulkFinalize !== nextState.isConfirmingBulkFinalize
       || this.state.currentPageIndex !== nextState.currentPageIndex
+      || this.state.isEditingPageIndex !== nextState.isEditingPageIndex
       || this.state.itemsPerPage !== nextState.itemsPerPage;
   }
 
@@ -173,10 +175,29 @@ class DomainManager extends Component {
     );
   }
 
+  handlePageJump(event, max) {
+    if (event.key !== 'Enter') return;
+    const {value} = event.currentTarget;
+    if (value === '') {
+      this.setState({isEditingPageIndex: false});
+      return;
+    }
+    let page = parseInt(value);
+    if (isNaN(page)) return;
+    page = Math.max(1, page);
+    page = Math.min(page, max);
+
+    this.setState({
+      currentPageIndex: page - 1,
+      isEditingPageIndex: false,
+    });
+  }
+
   renderControls(namesList) {
     const {
       currentPageIndex,
       itemsPerPage,
+      isEditingPageIndex,
     } = this.state;
 
     const totalPages = Math.ceil(namesList.length / itemsPerPage);
@@ -189,6 +210,7 @@ class DomainManager extends Component {
             className="domain-manager__page-control__start"
             onClick={() => this.setState({
               currentPageIndex: Math.max(currentPageIndex - 1, 0),
+              isEditingPageIndex: false,
             })}
           />
           {pageIndices.map((pageIndex, i) => {
@@ -198,13 +220,28 @@ class DomainManager extends Component {
               );
             }
 
+            if (isEditingPageIndex && currentPageIndex === pageIndex) {
+              return (
+                <div key={`${pageIndex}-${i}`} className="domain-manager__page-control__input">
+                  <input
+                  type="number"
+                  autoFocus
+                  placeholder={currentPageIndex+1}
+                  onKeyDown={event => this.handlePageJump(event, totalPages)}
+                />
+                </div>
+              )
+            }
+
             return (
               <div
                 key={`${pageIndex}-${i}`}
                 className={c('domain-manager__page-control__page', {
                   'domain-manager__page-control__page--active': currentPageIndex === pageIndex,
                 })}
-                onClick={() => this.setState({currentPageIndex: pageIndex})}
+                onClick={() => currentPageIndex === pageIndex ?
+                  this.setState({isEditingPageIndex: true})
+                  : this.setState({ currentPageIndex: pageIndex, isEditingPageIndex: false })}
               >
                 {pageIndex + 1}
               </div>
@@ -214,6 +251,7 @@ class DomainManager extends Component {
             className="domain-manager__page-control__end"
             onClick={() => this.setState({
               currentPageIndex: Math.min(currentPageIndex + 1, totalPages - 1),
+              isEditingPageIndex: false,
             })}
           />
         </div>

--- a/app/pages/Exchange/index.js
+++ b/app/pages/Exchange/index.js
@@ -73,6 +73,7 @@ class Exchange extends Component {
       isLoading: true,
       shakedexDeprecatedToggle: false,
       currentBidsMap: new Map(),
+      isEditingPageIndex: false,
     };
   }
 
@@ -484,7 +485,25 @@ class Exchange extends Component {
     );
   }
 
+  handlePageJump(event, max) {
+    if (event.key !== 'Enter') return;
+    const {value} = event.currentTarget;
+    if (value === '') {
+      this.setState({isEditingPageIndex: false});
+      return;
+    }
+    let page = parseInt(value);
+    if (isNaN(page)) return;
+    page = Math.max(1, page);
+    page = Math.min(page, max);
+
+    this.props.setAuctionPage(page)
+    this.setState({isEditingPageIndex: false});
+    this.fetchShakedex();
+  }
+
   renderListingControls = () => {
+    const {isEditingPageIndex} = this.state;
     const {
       auctions,
       total,
@@ -507,6 +526,7 @@ class Exchange extends Component {
             className="domain-manager__page-control__start"
             onClick={async () => {
               this.props.setAuctionPage(Math.max(currentPageIndex - 1, 1));
+              this.setState({isEditingPageIndex: false});
               this.fetchShakedex();
             }}
           />
@@ -517,6 +537,19 @@ class Exchange extends Component {
               );
             }
 
+            if (isEditingPageIndex && currentPageIndex === pageIndex + 1) {
+              return (
+                <div key={`${pageIndex}-${i}`} className="domain-manager__page-control__input">
+                  <input
+                  type="number"
+                  autoFocus
+                  placeholder={currentPageIndex+1}
+                  onKeyDown={event => this.handlePageJump(event, totalPages)}
+                />
+                </div>
+              )
+            }
+
             return (
               <div
                 key={`${pageIndex}-${i}`}
@@ -524,8 +557,13 @@ class Exchange extends Component {
                   'domain-manager__page-control__page--active': currentPageIndex === pageIndex + 1,
                 })}
                 onClick={async () => {
-                  this.props.setAuctionPage(pageIndex + 1);
-                  this.fetchShakedex();
+                  if (currentPageIndex === pageIndex + 1) {
+                    this.setState({isEditingPageIndex: true})
+                  } else {
+                    this.props.setAuctionPage(pageIndex + 1);
+                    this.setState({isEditingPageIndex: false});
+                    this.fetchShakedex();
+                  }
                 }}
               >
                 {pageIndex + 1}
@@ -536,6 +574,7 @@ class Exchange extends Component {
             className="domain-manager__page-control__end"
             onClick={async () => {
               this.props.setAuctionPage(Math.min(currentPageIndex + 1, totalPages));
+              this.setState({isEditingPageIndex: false});
               this.fetchShakedex();
             }}
           />

--- a/app/pages/Watching/index.js
+++ b/app/pages/Watching/index.js
@@ -49,6 +49,7 @@ class Watching extends Component {
     query: '',
     showError: false,
     currentPageIndex: 0,
+    isEditingPageIndex: false,
     itemsPerPage: 10,
     isConfirmingReset: false,
     isImporting: false,
@@ -356,10 +357,29 @@ class Watching extends Component {
     )
   }
 
+  handlePageJump(event, max) {
+    if (event.key !== 'Enter') return;
+    const {value} = event.currentTarget;
+    if (value === '') {
+      this.setState({isEditingPageIndex: false});
+      return;
+    }
+    let page = parseInt(value);
+    if (isNaN(page)) return;
+    page = Math.max(1, page);
+    page = Math.min(page, max);
+
+    this.setState({
+      currentPageIndex: page - 1,
+      isEditingPageIndex: false,
+    });
+  }
+
   renderControls() {
     const {
       currentPageIndex,
       itemsPerPage,
+      isEditingPageIndex,
     } = this.state;
     const {
       names,
@@ -375,6 +395,7 @@ class Watching extends Component {
             className="domain-manager__page-control__start"
             onClick={() => this.setState({
               currentPageIndex: Math.max(currentPageIndex - 1, 0),
+              isEditingPageIndex: false,
             })}
           />
           {pageIndices.map((pageIndex, i) => {
@@ -384,13 +405,28 @@ class Watching extends Component {
               );
             }
 
+            if (isEditingPageIndex && currentPageIndex === pageIndex) {
+              return (
+                <div key={`${pageIndex}-${i}`} className="domain-manager__page-control__input">
+                  <input
+                  type="number"
+                  autoFocus
+                  placeholder={currentPageIndex+1}
+                  onKeyDown={event => this.handlePageJump(event, totalPages)}
+                />
+                </div>
+              )
+            }
+
             return (
               <div
                 key={`${pageIndex}-${i}`}
                 className={c('domain-manager__page-control__page', {
                   'domain-manager__page-control__page--active': currentPageIndex === pageIndex,
                 })}
-                onClick={() => this.setState({ currentPageIndex: pageIndex })}
+                onClick={() => currentPageIndex === pageIndex ?
+                  this.setState({isEditingPageIndex: true})
+                  : this.setState({ currentPageIndex: pageIndex, isEditingPageIndex: false })}
               >
                 {pageIndex + 1}
               </div>
@@ -400,6 +436,7 @@ class Watching extends Component {
             className="domain-manager__page-control__end"
             onClick={() => this.setState({
               currentPageIndex: Math.min(currentPageIndex + 1, totalPages - 1),
+              isEditingPageIndex: false,
             })}
           />
         </div>

--- a/app/pages/YourBids/index.js
+++ b/app/pages/YourBids/index.js
@@ -50,6 +50,7 @@ class YourBids extends Component {
     isShowingNameClaimForPayment: false,
     activeFilter: '',
     currentPageIndex: 0,
+    isEditingPageIndex: false,
     itemsPerPage: 10,
     query: '',
     loading: true,
@@ -231,10 +232,29 @@ class YourBids extends Component {
     )
   }
 
+  handlePageJump(event, max) {
+    if (event.key !== 'Enter') return;
+    const {value} = event.currentTarget;
+    if (value === '') {
+      this.setState({isEditingPageIndex: false});
+      return;
+    }
+    let page = parseInt(value);
+    if (isNaN(page)) return;
+    page = Math.max(1, page);
+    page = Math.min(page, max);
+
+    this.setState({
+      currentPageIndex: page - 1,
+      isEditingPageIndex: false,
+    });
+  }
+
   renderControls() {
     const {
       currentPageIndex,
       itemsPerPage,
+      isEditingPageIndex,
     } = this.state;
 
     const yourBids = this.getCurrentBids();
@@ -249,6 +269,7 @@ class YourBids extends Component {
             className="domain-manager__page-control__start"
             onClick={() => this.setState({
               currentPageIndex: Math.max(currentPageIndex - 1, 0),
+              isEditingPageIndex: false,
             })}
           />
           {pageIndices.map((pageIndex, i) => {
@@ -258,13 +279,28 @@ class YourBids extends Component {
               );
             }
 
+            if (isEditingPageIndex && currentPageIndex === pageIndex) {
+              return (
+                <div key={`${pageIndex}-${i}`} className="domain-manager__page-control__input">
+                  <input
+                  type="number"
+                  autoFocus
+                  placeholder={currentPageIndex+1}
+                  onKeyDown={event => this.handlePageJump(event, totalPages)}
+                />
+                </div>
+              )
+            }
+
             return (
               <div
                 key={`${pageIndex}-${i}`}
                 className={c('domain-manager__page-control__page', {
                   'domain-manager__page-control__page--active': currentPageIndex === pageIndex,
                 })}
-                onClick={() => this.setState({ currentPageIndex: pageIndex })}
+                onClick={() => currentPageIndex === pageIndex ?
+                  this.setState({isEditingPageIndex: true})
+                  : this.setState({ currentPageIndex: pageIndex, isEditingPageIndex: false })}
               >
                 {pageIndex + 1}
               </div>
@@ -274,6 +310,7 @@ class YourBids extends Component {
             className="domain-manager__page-control__end"
             onClick={() => this.setState({
               currentPageIndex: Math.min(currentPageIndex + 1, totalPages - 1),
+              isEditingPageIndex: false,
             })}
           />
         </div>


### PR DESCRIPTION
Closes #622.
On clicking the current page number, it switches to an input box and can jump to a specific page. Applies to Transactions, MyDomains, Exchange, Watching, YourBids

![image](https://github.com/kyokan/bob-wallet/assets/5113343/a69eeec3-a83b-4213-ae94-b9543c559902)
