### PR TITLE
yourBids: sort bids by height and name state

### DIFF
--- a/app/pages/YourBids/index.js
+++ b/app/pages/YourBids/index.js
@@ -299,7 +299,7 @@ class YourBids extends Component {
     if (!this.fuse) {
       this.fuse = new Fuse(yourBids, {
         keys: ['name'],
-        threshold: .4,
+        threshold: 0.4,
       });
     }
 


### PR DESCRIPTION
Closes #395.

Now, bids in the Your Bids page are sorted by:
- First, state (active bids in bidding period come first, then reveal period, etc.)
- Within each state, by earliest auction start (i.e. lowest "time left" first)

Same order applies to the filter tabs (only bidding, only reveal, etc.)

Example:
- Names were opened in order: `cherry`, `dragon`, `elephant`.
- `cherry` is in reveal so is pushed down, the other 2 in bidding are on top
- `dragon` first over `elephant` because 19m < 40m

![image](https://github.com/kyokan/bob-wallet/assets/5113343/fa1fcd7f-81e5-4e03-a269-db77cbf36e09)
