### PR TITLE
account: show incomplete data info when not fully synced

### DIFF
--- a/app/pages/Account/account.scss
+++ b/app/pages/Account/account.scss
@@ -74,7 +74,6 @@
     width: 1.125rem;
     background-size: contain;
     background-repeat: no-repeat;
-    opacity: 0.5;
     cursor: pointer;
   }
 
@@ -115,6 +114,14 @@
         margin-right: 4px;
         background-image: url("../../assets/images/brick-loader.svg");
       }
+    }
+
+    &__syncing {
+      @extend %h4;
+      @extend %row-nowrap;
+      align-items: center;
+      color: $manatee-gray;
+      font-weight: 500;
     }
   }
 

--- a/app/pages/Account/index.js
+++ b/app/pages/Account/index.js
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import Transactions from "../../components/Transactions";
 import PhraseMismatch from "../../components/PhraseMismatch";
 import ShakedexDeprecated from '../../components/ShakedexDeprecated';
+import Tooltipable from '../../components/Tooltipable';
 import "./account.scss";
 import walletClient from "../../utils/walletClient";
 import { displayBalance } from "../../utils/balances";
@@ -33,6 +34,10 @@ const analytics = aClientStub(() => require("electron").ipcRenderer);
     hnsPrice: state.node.hnsPrice,
     walletInitialized: state.wallet.initialized,
     walletType: state.wallet.type,
+    isSynchronized: (
+      state.node.isRunning
+      && state.node.chain.progress === 1
+    ),
   }),
   (dispatch) => ({
     fetchWallet: () => dispatch(walletActions.fetchWallet()),
@@ -66,6 +71,7 @@ export default class Account extends Component {
     history: PropTypes.object.isRequired,
     walletInitialized: PropTypes.bool.isRequired,
     walletType: PropTypes.string.isRequired,
+    isSynchronized: PropTypes.bool.isRequired,
   };
 
   static contextType = I18nContext;
@@ -170,7 +176,7 @@ export default class Account extends Component {
 
   render() {
     const {t} = this.context;
-    const { isFetching } = this.props;
+    const { isFetching, isSynchronized } = this.props;
 
     return (
       <div className="account">
@@ -184,6 +190,20 @@ export default class Account extends Component {
         <div className="account__transactions">
           <div className="account__panel-title">
             {t('transactionHistory')}
+
+            {!isSynchronized ? 
+              <div className="account__transactions__syncing">
+                <Tooltipable
+                  tooltipContent={t('incompleteDataUntilSyncDesc')}
+                >
+                  <div className="account__info-icon" />
+                </Tooltipable>
+                <span style={{marginLeft: '0.2rem'}}>
+                  {t('incompleteDataUntilSyncInfo')}
+                </span>
+              </div>
+            : null}
+
             {isFetching && (
               <div className="account__transactions__loading">
                 Loading transactions...

--- a/app/pages/Auction/domains.scss
+++ b/app/pages/Auction/domains.scss
@@ -269,6 +269,8 @@
 
       &__cta {
         @extend %btn-primary;
+        display: flex;
+        justify-content: center;
         font-weight: 600;
       }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -198,6 +198,8 @@
   "inBids": "In bids",
   "inFinishedAuctions": "In finished auctions",
   "inReveals": "In reveal",
+  "incompleteDataUntilSyncDesc": "Data displayed is as of the current sync height. As it catches up with newer blocks, all transactions will be picked up and the balance will be accurate.",
+  "incompleteDataUntilSyncInfo": "May not be up to date until sync is complete",
   "inputs": "Inputs",
   "invalidAddress": "Invalid Address",
   "invalidTransactionFile": "Invalid Transaction File",


### PR DESCRIPTION
Closes #615.

New Bob users don't always know to wait for the node to fully sync. This adds an info tooltip explaining it.

![image](https://github.com/kyokan/bob-wallet/assets/5113343/fddc7c0a-f934-404b-9607-5af387ef9d5c)

(on `i` hover):
![image](https://github.com/kyokan/bob-wallet/assets/5113343/f4d943bc-74a8-4249-82cf-120547a479b8)
