### PR TITLE
ci: update node-gyp

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: ['16']
+        node-version: ['18']
 
         # OS-specific commands/variables
         include:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: ['18']
+        node-version: ['16', '18']
 
         # OS-specific commands/variables
         include:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # https://github.com/actions/setup-node/issues/280#issuecomment-1139455898
+      - name: Update node-gyp (windows only)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $WhereNode = Get-Command node | Select-Object -ExpandProperty Definition
+          $NodeDirPath = Split-Path $WhereNode -Parent
+          $NodeModulesPath = $NodeDirPath + "\node_modules\npm\node_modules\@npmcli\run-script"
+          cd $NodeModulesPath
+          npm install node-gyp@latest
+
       - name: Install dependencies (linux only)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt install libudev-dev libusb-1.0-0-dev -y

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "npm"
 
       - name: Install dependencies (linux only)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-18.04, macos-latest]
+        os: [windows-latest, ubuntu-20.04, macos-latest]
 
         # OS-specific commands/variables
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             cmd_package: npm run package-linux
             out_filename: Bob-linux
           - os: windows-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,17 +36,22 @@ jobs:
           node-version: 18
           cache: "npm"
 
+      # https://github.com/actions/setup-node/issues/280#issuecomment-1139455898
+      - name: Update node-gyp (windows only)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $WhereNode = Get-Command node | Select-Object -ExpandProperty Definition
+          $NodeDirPath = Split-Path $WhereNode -Parent
+          $NodeModulesPath = $NodeDirPath + "\node_modules\npm\node_modules\@npmcli\run-script"
+          cd $NodeModulesPath
+          npm install node-gyp@latest
+
       - name: Install dependencies (linux only)
         if: startsWith(matrix.os, 'ubuntu')
         run: sudo apt update && sudo apt install libudev-dev libusb-1.0-0-dev -y
 
       - name: Install npm packages
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_on: error
-          command: npm i
+        run: npm i
 
       - name: Install dmg-license (macos only)
         if: startsWith(matrix.os, 'macos')


### PR DESCRIPTION
Closes #595.

With https://github.com/nodejs/node-gyp/issues/2683 finally resolved, windows builds failing 50% of the time shouldn't happen anymore. Will run CI on this a couple of times to confirm.

Also updates a few versions for os, actions, nodejs.