### PR TITLE
Disable tree compact bump version to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ brew install kyokan-bob
 4. Compare a checksum of a downloaded Bob Wallet app file:
 ```
 # Linux
-sha256sum Bob-2.0.0.AppImage
+sha256sum Bob-2.1.0.AppImage
 
 # Windows
-certUtil -hashfile Bob-2.0.0.msi SHA256
+certUtil -hashfile Bob-2.1.0.msi SHA256
 
 # macOS
-shasum -a 256 Bob-2.0.0-x86.dmg
-shasum -a 256 bob-2.0.0-arm64.dmg
+shasum -a 256 Bob-2.1.0-x86.dmg
+shasum -a 256 bob-2.1.0-arm64.dmg
 ```
 
 For more details and more advanced PGP signature verification see https://github.com/kyokan/bob-wallet/pull/612.
@@ -112,7 +112,7 @@ be run in an environment where `libunbound` is available as an x86 package.
 
 ```bash
 npm run package-mac-intel
-``` 
+```
 
 The output app will be created in the `/release/mac` or `/release/mac-arm64` folder.
 Open `Bob.app` to start the wallet.

--- a/app/background/node/service.js
+++ b/app/background/node/service.js
@@ -239,7 +239,7 @@ export class NodeService extends EventEmitter {
       walletMigrate: 2,
       walletIcannlockup: true,
       maxOutbound: 4,
-      compactTreeOnInit: true,
+      compactTreeOnInit: false,
     });
 
     this.hsd.use(plugin);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bob-wallet",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bob-wallet",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bob-wallet",
   "productName": "Bob",
   "author": "Kyokan Group, Inc.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Handshake wallet and auction manager.",
   "scripts": {
     "build": "./scripts/package.sh",


### PR DESCRIPTION
Tree compact takes too long and unexpected delays when accessing wallets isn't very nice. Will add it back in the future as a manual setting.

If someone wants to compact now, it's still possible with cli:
```sh
hsd-rpc compacttree
```
